### PR TITLE
Add Gradle version catalog for dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
 plugins {
-    kotlin("jvm") version "2.2.20"
-    id("org.jlleitschuh.gradle.ktlint") version "13.1.0"
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.ktlint)
 }
 
 

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,19 +1,19 @@
 plugins {
-    kotlin("jvm") version "2.2.20"
+    alias(libs.plugins.kotlin.jvm)
     application
-    id("io.github.cdsap.fatbinary") version "1.0"
+    alias(libs.plugins.fatbinary)
 }
 
 group = "org.example"
 version = "1.0-SNAPSHOT"
 
 dependencies {
-    implementation("com.github.ajalt.clikt:clikt:5.0.3")
+    implementation(libs.clikt)
     implementation(project(":project-generator"))
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.3")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.3")
-    testImplementation(platform("org.junit:junit-bom:6.0.0"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.jackson.dataformat.yaml)
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
 }
 
 tasks.test {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,24 @@
+[versions]
+kotlin = "2.2.20"
+ktlint = "13.1.0"
+mavenPublish = "0.34.0"
+fatbinary = "1.0"
+coroutines = "1.10.2"
+junit = "6.0.0"
+clikt = "5.0.3"
+jackson = "2.12.3"
+
+[libraries]
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
+clikt = { group = "com.github.ajalt.clikt", name = "clikt", version.ref = "clikt" }
+jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson" }
+jackson-dataformat-yaml = { group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-yaml", version.ref = "jackson" }
+junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit" }
+junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter" }
+junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
+fatbinary = { id = "io.github.cdsap.fatbinary", version.ref = "fatbinary" }

--- a/project-generator/build.gradle.kts
+++ b/project-generator/build.gradle.kts
@@ -1,19 +1,19 @@
 plugins {
-    kotlin("jvm") version "2.2.20"
+    alias(libs.plugins.kotlin.jvm)
     `maven-publish`
     `signing`
-    id("com.vanniktech.maven.publish") version "0.34.0"
+    alias(libs.plugins.maven.publish)
 }
 
 group = "io.github.cdsap"
 version = "0.3.5"
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
-    testImplementation(platform("org.junit:junit-bom:6.0.0"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
+    implementation(libs.kotlinx.coroutines.core)
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
     testImplementation(gradleTestKit())
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 tasks.test {


### PR DESCRIPTION
## Summary
- migrate Gradle builds to use the shared `libs` version catalog for plugins and dependencies
- centralize versions for Kotlin, ktlint, Jackson, Clikt, and testing dependencies in `gradle/libs.versions.toml`

## Testing
- `./gradlew test` *(fails: Java 23 toolchain is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e554fff89083308d205ff3928d5486