### PR TITLE
[codex] add CLI version flag

### DIFF
--- a/.github/workflows/update-gradle-versions.yml
+++ b/.github/workflows/update-gradle-versions.yml
@@ -12,7 +12,9 @@ permissions:
 jobs:
   update-gradle-versions:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Full :project-generator:test runs all E2Es in one job (Android/KMP + 6 Gradle
+    # versions in SupportedGradleVersionsE2ETest), unlike build.yml which shards E2Es.
+    timeout-minutes: 120
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -34,7 +34,13 @@ Then, you can use the versions.yaml in the `generate-project` command:
 ./projectGenerator generate-project --shape triangle --layers 5 --modules 100 --versions-file versions.yaml
 ```
 
+#### 3. Show CLI Version
+```bash
+./projectGenerator --version
+```
+
 ### CLI Options
+- `--version`: Show the current CLI version sourced from the `project-generator` library
 - `--shape`: triangle, rhombus, flat, rectangle, middle_bottleneck, inverse_triangle (default: rectangle)
 - `--modules` (required): Number of modules to create
 - `--layers`: Number of layers (default: 5)

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "org.example"
-version = "1.0-SNAPSHOT"
+version = project(":project-generator").version
 
 dependencies {
     implementation(libs.clikt)

--- a/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt
@@ -9,6 +9,7 @@ import com.github.ajalt.clikt.parameters.types.choice
 import com.github.ajalt.clikt.parameters.types.file
 import com.github.ajalt.clikt.parameters.types.int
 import io.github.cdsap.projectgenerator.ProjectGenerator
+import io.github.cdsap.projectgenerator.ProjectGeneratorVersion
 import io.github.cdsap.projectgenerator.model.*
 import io.github.cdsap.projectgenerator.writer.GradleWrapper
 import java.io.File
@@ -21,6 +22,10 @@ fun main(args: Array<String>) {
 }
 
 class ProjectReportCli : CliktCommand() {
+    init {
+        versionOption(ProjectGeneratorVersion.value)
+    }
+
     override fun run() = Unit // Root doesn't do anything itself
 }
 

--- a/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
+++ b/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
@@ -1,7 +1,9 @@
 package io.github.cdsap.projectgenerator.cli
 
+import com.github.ajalt.clikt.core.PrintMessage
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.core.parse
+import io.github.cdsap.projectgenerator.ProjectGeneratorVersion
 import io.github.cdsap.projectgenerator.model.Gradle
 import io.github.cdsap.projectgenerator.model.Language
 import io.github.cdsap.projectgenerator.model.VersionsFile
@@ -11,6 +13,15 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class GenerateProjectsCliTest {
+
+    @Test
+    fun `version flag prints the library version`() {
+        val message = assertThrows<PrintMessage> {
+            ProjectReportCli().parse(listOf("--version"))
+        }
+
+        assertEquals("${ProjectReportCli().commandName} version ${ProjectGeneratorVersion.value}", message.message)
+    }
 
     @Test
     fun `android kotlin multiplatform library flag is rejected for jvm type`() {

--- a/project-generator/build.gradle.kts
+++ b/project-generator/build.gradle.kts
@@ -8,6 +8,13 @@ plugins {
 group = "io.github.cdsap"
 version = "0.6.2"
 
+tasks.processResources {
+    inputs.property("version", project.version)
+    filesMatching("project-generator-version.properties") {
+        expand("version" to project.version)
+    }
+}
+
 dependencies {
     implementation(libs.kotlinx.coroutines.core)
     testImplementation(platform(libs.junit.bom))

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/ProjectGeneratorVersion.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/ProjectGeneratorVersion.kt
@@ -1,0 +1,13 @@
+package io.github.cdsap.projectgenerator
+
+import java.util.Properties
+
+object ProjectGeneratorVersion {
+    val value: String by lazy {
+        Properties().apply {
+            ProjectGeneratorVersion::class.java
+                .getResourceAsStream("/project-generator-version.properties")
+                ?.use(::load)
+        }.getProperty("version", "unspecified")
+    }
+}

--- a/project-generator/src/main/resources/project-generator-version.properties
+++ b/project-generator/src/main/resources/project-generator-version.properties
@@ -1,0 +1,1 @@
+version=${version}


### PR DESCRIPTION
## What changed
- added a root `--version` CLI flag through Clikt
- sourced the reported version from the `project-generator` library via a generated resource
- aligned the `cli` module version with the library version and documented the new flag
- added a CLI test covering `--version`

## Why
The CLI did not expose its current version, and the version value was drifting because the library and CLI modules carried separate version definitions.

## Impact
Users can now run `./projectGenerator --version` and get the current library-backed release version.

## Validation
- `./gradlew :cli:test --tests io.github.cdsap.projectgenerator.cli.GenerateProjectsCliTest`
