### PR TITLE
fix: small rhombus and middle_bottleneck projects crash during graph gen

### DIFF
--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/Distributions.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/Distributions.kt
@@ -48,6 +48,14 @@ class Distributions {
             layer++
         }
 
+        distribution.indices.filter { distribution[it] == 0 }.forEach { emptyLayer ->
+            val donorLayer = distribution.indices.maxByOrNull { distribution[it] }
+            if (donorLayer != null && distribution[donorLayer] > 1) {
+                distribution[donorLayer]--
+                distribution[emptyLayer]++
+            }
+        }
+
         return distribution
     }
 

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/ProjectGraphGenerator.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/ProjectGraphGenerator.kt
@@ -112,8 +112,8 @@ class ProjectGraphGenerator(
         } else {
 
             for (i in 0 until numberModules) {
-                if (numberModulesUpperLayer == 1) {
-                    listOfModules.add(1)
+                if (numberModulesUpperLayer <= 1) {
+                    listOfModules.add(numberModulesUpperLayer)
                 } else {
                     var next = Random.nextInt(1, numberModulesUpperLayer)
                     listOfModules.add(next)

--- a/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/ProjectGraphGeneratorTest.kt
+++ b/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/ProjectGraphGeneratorTest.kt
@@ -2,11 +2,44 @@ package io.github.cdsap.projectgenerator
 
 import io.github.cdsap.projectgenerator.model.ClassesPerModule
 import io.github.cdsap.projectgenerator.model.ClassesPerModuleType
+import io.github.cdsap.projectgenerator.model.Shape
 import io.github.cdsap.projectgenerator.model.TypeProjectRequested
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 
 class ProjectGraphGeneratorTest {
+
+    @ParameterizedTest
+    @EnumSource(Shape::class)
+    fun `generates every shape at the minimum module count`(shape: Shape) {
+        val layers = 5
+        val distribution = LayerDistribution(numberOfModules = layers + 1, numberOfLayers = layers).get(shape)
+
+        val nodes = ProjectGraphGenerator(
+            if (shape == Shape.FLAT) 1 else layers,
+            distribution,
+            TypeProjectRequested.JVM,
+            ClassesPerModule(ClassesPerModuleType.FIXED, 10)
+        ).generate()
+
+        assertTrue(distribution.all { it > 0 })
+        assertEquals(distribution.sum() + 1, nodes.size)
+        assertEquals(if (shape == Shape.FLAT) 1 else layers, nodes.last().layer)
+    }
+
+    @Test
+    fun `generates a graph when the previous layer is empty`() {
+        val nodes = ProjectGraphGenerator(
+            numberOfLayers = 3,
+            distribution = listOf(1, 0, 1),
+            typeOfProjectRequested = TypeProjectRequested.JVM,
+            classesPerModule = ClassesPerModule(ClassesPerModuleType.FIXED, 10)
+        ).generate()
+
+        assertTrue(nodes.single { it.layer == 2 }.nodes.isEmpty())
+    }
 
     @Test
     fun testLayerHasRelationWithPreviousLayer() {


### PR DESCRIPTION
## Summary

        Automated Codex implementation for cdsap/ProjectGenerator#363: Small rhombus and middle_bottleneck projects crash during graph generation

        Fixes #363

        ## Verification

        - `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`