### PR TITLE
fix: language=both writes graph.dot only to the groovy output

### DIFF
--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/ProjectGenerator.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/ProjectGenerator.kt
@@ -68,7 +68,9 @@ class ProjectGenerator(
             develocity,
             projectName
         ).write()
-        GraphWriter(nodes, projectLanguageAttributes.first().projectName).write()
+        projectLanguageAttributes.forEach { attributes ->
+            GraphWriter(nodes, attributes.projectName).write()
+        }
         println("Project created in ${projectLanguageAttributes.first().projectName}")
     }
 

--- a/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/ProjectGeneratorTest.kt
+++ b/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/ProjectGeneratorTest.kt
@@ -69,5 +69,7 @@ class ProjectGeneratorTest {
 
         assert(File("$tempDir/project_kts/build.gradle.kts").exists())
         assert(File("$tempDir/project_groovy/build.gradle").exists())
+        assert(File("$tempDir/project_kts/graph.dot").exists())
+        assert(File("$tempDir/project_groovy/graph.dot").exists())
     }
 }


### PR DESCRIPTION
## Summary

        Automated Codex implementation for cdsap/ProjectGenerator#362: language=both writes graph.dot only to the Groovy output

        Fixes #362

        ## Verification

        - `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`