### PR TITLE
fix: --room-database is silently ignored for jvm projects

### DIFF
--- a/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt
@@ -64,6 +64,9 @@ class GenerateProjects : CliktCommand(name = "generate-project") {
         val typeOfProjectRequested = TypeProjectRequested.valueOf(type.uppercase())
         val shape = Shape.valueOf(shape.uppercase())
         val dependencyInjection = DependencyInjection.valueOf(di.uppercase())
+        if (typeOfProjectRequested != TypeProjectRequested.ANDROID && roomDatabase) {
+            throw UsageError("--room-database is only available when --type android.")
+        }
         if (typeOfProjectRequested != TypeProjectRequested.ANDROID && kotlinMultiplatformLibrary) {
             throw UsageError("--android-kotlin-multiplatform-library is only available when --type android.")
         }

--- a/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
+++ b/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
@@ -13,6 +13,20 @@ import org.junit.jupiter.api.assertThrows
 class GenerateProjectsCliTest {
 
     @Test
+    fun `room database flag is rejected for jvm type`() {
+        val error = assertThrows<UsageError> {
+            GenerateProjects().parse(
+                listOf(
+                    "--modules", "6",
+                    "--type", "jvm",
+                    "--room-database"
+                )
+            )
+        }
+        assertTrue(error.message?.contains("--room-database is only available when --type android.") == true)
+    }
+
+    @Test
     fun `android kotlin multiplatform library flag is rejected for jvm type`() {
         val error = assertThrows<UsageError> {
             GenerateProjects().parse(


### PR DESCRIPTION
## Summary

        Automated Codex implementation for cdsap/ProjectGenerator#361: --room-database is silently ignored for JVM projects

        Fixes #361

        ## Verification

        - `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`