### PR TITLE
fix: readme cli examples use invalid options and flag syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ By default, projects are generated under `projects_generated/<projectName>/proje
 
 #### Example: Generate a project with custom options
 ```bash
-./projectGenerator generate-project --shape rhombus --modules 50 --layers 4 --language both --type jvm --classesModule 10 --classesModuleType random --typeOfStringResources large --generateUnitTest --gradle gradle_8_9 --develocity --versionsFile ./my_versions.yaml
+./projectGenerator generate-project --shape rhombus --modules 50 --layers 4 --language both --type jvm --classes-module 10 --classes-module-type random --type-of-string-resources large --generate-unit-test --gradle gradle_8_14_4 --develocity
 ```
 
 ## Library
@@ -195,8 +195,8 @@ Each module generated includes 900 string resources in the file `strings.xml`
 If enabled, each module will generate n unit tests, where n is the argument `classes`
 
 ##### Example
-```kotlin
-./projectGenerator  generate-project  --shape triangle --layers 5 --modules 100 --generate-unit-test true
+```bash
+./projectGenerator  generate-project  --shape triangle --layers 5 --modules 100 --generate-unit-test
 ```
 ## Gradle
 Gradle used, versions supported:

--- a/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/ReadmeCliExamplesTest.kt
+++ b/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/ReadmeCliExamplesTest.kt
@@ -1,0 +1,48 @@
+package io.github.cdsap.projectgenerator.cli
+
+import com.github.ajalt.clikt.core.MultiUsageError
+import com.github.ajalt.clikt.core.parse
+import com.github.ajalt.clikt.core.subcommands
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.readText
+
+class ReadmeCliExamplesTest {
+
+    @TempDir
+    lateinit var outputDir: Path
+
+    @Test
+    fun `maintained README CLI examples run successfully`() {
+        val readme = Path.of("..", "README.md").readText()
+
+        listOf(
+            "#### Example: Generate a project with custom options",
+            "## Generate Unit Test"
+        ).forEachIndexed { index, heading ->
+            val arguments = readme.commandAfter(heading).split(Regex("\\s+")).drop(1)
+
+            try {
+                ProjectReportCli()
+                    .subcommands(GenerateProjects(), GenerateYaml())
+                    .parse(arguments + listOf("--output-dir", outputDir.resolve("example-$index").toString()))
+            } catch (exception: Exception) {
+                val message = if (exception is MultiUsageError) {
+                    exception.errors.joinToString { it.message.orEmpty() }
+                } else {
+                    exception.message
+                }
+                throw AssertionError("README example failed: $heading: $message", exception)
+            }
+        }
+    }
+
+    private fun String.commandAfter(heading: String): String {
+        require(heading in this) { "README heading not found: $heading" }
+        return substringAfter(heading)
+            .substringAfter("```bash")
+            .substringBefore("```")
+            .trim()
+    }
+}


### PR DESCRIPTION
## Summary

        Automated Codex implementation for cdsap/ProjectGenerator#360: README CLI examples use invalid options and flag syntax

        Fixes #360

        ## Verification

        - `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`