### PR TITLE
fix: viewmodel tests are refencing incorrect repositories

### DIFF
--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/test/TestGeneratorAndroidLegacy.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/test/TestGeneratorAndroidLegacy.kt
@@ -50,12 +50,11 @@ class TestGeneratorAndroidLegacy(
         val testContent = when (classDefinition.type) {
             ClassTypeAndroid.REPOSITORY -> generateRepositoryTest(moduleDefinition, classDefinition, classesDictionary)
             ClassTypeAndroid.API -> generateApiTest(className)
-            // todo generate correct tests for viewModel
-//            ClassTypeAndroid.VIEWMODEL -> generateViewModelTest(
-//                className,
-//                classDefinition.dependencies,
-//                classesDictionary
-//            )
+            ClassTypeAndroid.VIEWMODEL -> generateViewModelTest(
+                className,
+                classDefinition.dependencies,
+                classesDictionary
+            )
 
             ClassTypeAndroid.WORKER -> generateWorkerTest(className)
             ClassTypeAndroid.ACTIVITY -> generateActivityTest(className)
@@ -98,19 +97,17 @@ class TestGeneratorAndroidLegacy(
                     appendLine("import kotlinx.coroutines.flow.first")
                 }
 
-               // ClassTypeAndroid.VIEWMODEL -> {
-                    // todo generate correct tests for viewModel
-//                    classDefinition.dependencies.forEach { dep ->
-//                        val s = classesDictionary.filter { it.key == dep.sourceModuleId }
-//                        if (s.isNotEmpty()) {
-//                            val x = s.values.flatten().first { it.type == ClassTypeAndroid.REPOSITORY }
-//                            if (x != null) {
-//                                val repository = x.className
-//                                appendLine("import com.awesomeapp.${NameMappings.modulePackageName(dep.sourceModuleId)}.$repository")
-//                            }
-//                        }
-//                    }
-             //   }
+                ClassTypeAndroid.VIEWMODEL -> {
+                    classDefinition.dependencies.forEach { dep ->
+                        val dependency = classesDictionary[dep.sourceModuleId]
+                            ?.firstOrNull { it.type == dep.type }
+                        if (dependency != null) {
+                            appendLine(
+                                "import com.awesomeapp.${NameMappings.modulePackageName(dep.sourceModuleId)}.${dependency.className}"
+                            )
+                        }
+                    }
+                }
 
                 ClassTypeAndroid.REPOSITORY -> {
                     classDefinition.dependencies.forEach { dep ->
@@ -199,60 +196,21 @@ class TestGeneratorAndroidLegacy(
         dependencies: List<ClassDependencyAndroid>,
         a: MutableMap<String, CopyOnWriteArrayList<GenerateDictionaryAndroid>>
     ): String {
-        val xa = mutableListOf<String>()
-        val xc = mutableListOf<String>()
-        dependencies.mapIndexed { index, dep ->
-            val s = a.filter { it.key == dep.sourceModuleId }
-            if (s.isNotEmpty()) {
-                val x = s.values.flatten().first { it.type == ClassTypeAndroid.REPOSITORY }
-                if (x != null) {
-                    val repository = x.className
-                    xa.add("repository$index: $repository")
-                }
+        val resolvedDependencies = dependencies.map { dependency ->
+            dependency to a.getValue(dependency.sourceModuleId).first { it.type == dependency.type }
+        }
+        val mockRepositories = resolvedDependencies.mapIndexed { index, (_, dependency) ->
+            "private lateinit var repository$index: ${dependency.className}"
+        }.joinToString("\n        ")
+        val repositoryInitializers = resolvedDependencies.mapIndexed { index, (_, dependency) ->
+            val constructorArguments = dependency.dependencies.joinToString(", ") { innerDependency ->
+                val innerClass = a.getValue(innerDependency.sourceModuleId).first { it.type == innerDependency.type }
+                "com.awesomeapp.${NameMappings.modulePackageName(innerDependency.sourceModuleId)}.${innerClass.className}()"
             }
+            "repository$index = ${dependency.className}($constructorArguments)"
         }
 
-        val constructorParams = xa.joinToString(",\n        ")
-
-        val xb = mutableListOf<String>()
-        dependencies.mapIndexed { index, dep ->
-            val s = a.filter { it.key == dep.sourceModuleId }
-            if (s.isNotEmpty()) {
-                val x = s.values.flatten().first { it.type == ClassTypeAndroid.REPOSITORY }
-                if (x != null) {
-                    val repository = x.className
-                    xb.add("private lateinit var repository$index: $repository")
-                }
-            }
-        }
-        val mockRepositories = xb.joinToString("\n        ")
-
-        dependencies.mapIndexed { index, dep ->
-
-            val s = a.filter { it.key == dep.sourceModuleId }
-            if (s.isNotEmpty()) {
-                val x = s.values.flatten().first { it.type == ClassTypeAndroid.REPOSITORY }
-                if (x != null) {
-                    val repository = x.className
-                    xc.add(
-                        "repository$index = $repository(${
-                            x.dependencies.mapIndexed { depIndex, innerDep ->
-                                val innerS = a.filter { it.key == innerDep.sourceModuleId }
-                                if (innerS.isNotEmpty()) {
-                                    val innerX = innerS.values.flatten().first { it.type == ClassTypeAndroid.API }
-                                    if (innerX != null) {
-                                        "com.awesomeapp.${NameMappings.modulePackageName(innerDep.sourceModuleId)}.${innerX.className}()"
-                                    } else ""
-                                } else ""
-                            }.joinToString(", ")
-                        })"
-                    )
-
-                }
-            }
-        }
-
-        val testContent = if (constructorParams.isNotEmpty()) {
+        val testContent = if (resolvedDependencies.isNotEmpty()) {
             """
             |    $mockRepositories
             |
@@ -260,9 +218,9 @@ class TestGeneratorAndroidLegacy(
             |
             |    @Before
             |    fun setup() {
-            |       ${xc.joinToString("\n        ")}
+            |       ${repositoryInitializers.joinToString("\n        ")}
             |        viewModel = $className(
-            |            ${dependencies.mapIndexed { index, _ -> "repository$index" }.joinToString(",\n            ")}
+            |            ${resolvedDependencies.indices.joinToString(",\n            ") { "repository$it" }}
             |        )
             |    }
             |

--- a/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/generator/test/TestGeneratorAndroidTest.kt
+++ b/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/generator/test/TestGeneratorAndroidTest.kt
@@ -2,13 +2,15 @@ package io.github.cdsap.projectgenerator.generator.test
 
 import io.github.cdsap.projectgenerator.DefaultTestVersions.Companion.LATEST_GRADLE
 import io.github.cdsap.projectgenerator.NameMappings
-import io.github.cdsap.projectgenerator.writer.ProjectWriter
+import io.github.cdsap.projectgenerator.generator.classes.GenerateDictionaryAndroid
 import io.github.cdsap.projectgenerator.model.*
 import io.github.cdsap.projectgenerator.writer.GradleWrapper
+import io.github.cdsap.projectgenerator.writer.ProjectWriter
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import org.junit.jupiter.api.Assertions.assertTrue
 import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
 
 class TestGeneratorAndroidTest {
     @TempDir
@@ -39,5 +41,50 @@ class TestGeneratorAndroidTest {
         assertTrue(testFile.exists(), "Test file should be generated")
         val content = testFile.readText()
         assertTrue(content.contains("class Viewmodel1_1Test"), "Test class should be present")
+    }
+
+    @Test
+    fun `viewmodel test references its declared repository and repository dependencies`() {
+        val moduleDefinition = ModuleClassDefinitionAndroid(
+            moduleId = "module_23_1",
+            layer = 23,
+            moduleNumber = 23,
+            classes = listOf(
+                ClassDefinitionAndroid(
+                    type = ClassTypeAndroid.VIEWMODEL,
+                    index = 1,
+                    dependencies = mutableListOf(
+                        ClassDependencyAndroid(ClassTypeAndroid.REPOSITORY, "module_12_1")
+                    )
+                )
+            )
+        )
+        val classesDictionary = mutableMapOf(
+            "module_12_1" to CopyOnWriteArrayList(
+                listOf(
+                    GenerateDictionaryAndroid("UnrelatedApi12_4", ClassTypeAndroid.API, 4, emptyList()),
+                    GenerateDictionaryAndroid(
+                        "Repository12_5",
+                        ClassTypeAndroid.REPOSITORY,
+                        5,
+                        listOf(ClassDependencyAndroid(ClassTypeAndroid.MODEL, "module_8_1"))
+                    )
+                )
+            ),
+            "module_8_1" to CopyOnWriteArrayList(
+                listOf(GenerateDictionaryAndroid("Model8_6", ClassTypeAndroid.MODEL, 6, emptyList()))
+            )
+        )
+
+        TestGeneratorAndroidLegacy().generate(moduleDefinition, tempDir.path, classesDictionary)
+
+        val testFile = File(
+            tempDir,
+            "${NameMappings.layerName(23)}/module_23_1/src/test/kotlin/com/awesomeapp/module_23_1/Viewmodel23_1Test.kt"
+        )
+        val content = testFile.readText()
+        assertTrue(content.contains("private lateinit var repository0: Repository12_5"))
+        assertTrue(content.contains("repository0 = Repository12_5(com.awesomeapp.module_8_1.Model8_6())"))
+        assertTrue(content.contains("viewModel = Viewmodel23_1("))
     }
 }


### PR DESCRIPTION
## Summary

        Automated Codex implementation for cdsap/ProjectGenerator#123: ViewModel tests are refencing incorrect repositories

        Fixes #123

        ## Verification

        - `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`