### PR TITLE
fix: generated jvm groovy projects fail to build

### DIFF
--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/rootproject/BuildGradle.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/rootproject/BuildGradle.kt
@@ -21,12 +21,20 @@ class BuildGradle {
         """.trimIndent()
 
 
-    fun getJvm(versions: Versions) = """
+    fun getJvm(versions: Versions, extension: String) = """
         plugins {
-            kotlin("jvm") version("${versions.kotlin.kgp}") apply false
+            ${jvmPlugin(versions, extension)}
             ${additionalBuildGradlePlugins(versions)}
         }
         """.trimIndent()
+
+    private fun jvmPlugin(versions: Versions, extension: String): String {
+        return if (extension == "gradle") {
+            "id 'org.jetbrains.kotlin.jvm' version '${versions.kotlin.kgp}' apply false"
+        } else {
+            "kotlin(\"jvm\") version(\"${versions.kotlin.kgp}\") apply false"
+        }
+    }
 
     fun provideKotlinProcessor(versions: Versions) = if (versions.kotlin.kotlinProcessor.processor == Processor.KAPT)
         """"""

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/ProjectWriter.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/ProjectWriter.kt
@@ -77,9 +77,12 @@ class ProjectWriter(
     private fun createProjectBuildGradle(
         languages: List<LanguageAttributes>
     ) {
-        val plugins = if (typeOfProjectRequested == TypeProjectRequested.JVM) BuildGradle().getJvm(versions)
-        else BuildGradle().getAndroid(versions, versions.di)
         languages.forEach {
+            val plugins = if (typeOfProjectRequested == TypeProjectRequested.JVM) {
+                BuildGradle().getJvm(versions, it.extension)
+            } else {
+                BuildGradle().getAndroid(versions, versions.di)
+            }
             File("${it.projectName}/build.${it.extension}").projectFile(plugins)
         }
     }

--- a/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/ProjectGeneratorE2ETest.kt
+++ b/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/ProjectGeneratorE2ETest.kt
@@ -120,6 +120,36 @@ class ProjectGeneratorE2ETest {
         assert(result.output.contains("BUILD SUCCESSFUL"))
     }
 
+    @ParameterizedTest
+    @EnumSource(value = Language::class, names = ["GROOVY", "BOTH"])
+    fun `jvm groovy projects build`(language: Language) {
+        val projectRoot = tempDir.resolve("jvm-${language.name.lowercase()}").toFile()
+        ProjectGenerator(
+            modules = 6,
+            shape = Shape.RECTANGLE,
+            language = language,
+            typeOfProjectRequested = TypeProjectRequested.JVM,
+            layers = 5,
+            gradle = GradleWrapper(LATEST_GRADLE),
+            projectRootPath = projectRoot.path,
+            projectName = "jvm-groovy"
+        ).write()
+
+        val generatedProjects = if (language == Language.BOTH) {
+            listOf(File(projectRoot, "project_groovy"), File(projectRoot, "project_kts"))
+        } else {
+            listOf(projectRoot)
+        }
+        generatedProjects.forEach { generatedProject ->
+            val result = GradleRunner.create()
+                .withProjectDir(generatedProject)
+                .withArguments("build")
+                .build()
+
+            assert(result.output.contains("BUILD SUCCESSFUL"))
+        }
+    }
+
     @Test
     fun changedVersionReflectsInTomlFile() {
         val modules = 30

--- a/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/generator/rootproject/BuildGradleTest.kt
+++ b/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/generator/rootproject/BuildGradleTest.kt
@@ -11,6 +11,21 @@ import org.junit.jupiter.api.Test
 
 class BuildGradleTest {
     @Test
+    fun `jvm groovy root build file uses groovy plugin syntax`() {
+        val result = BuildGradle().getJvm(Versions(), "gradle")
+
+        assertTrue(result.contains("id 'org.jetbrains.kotlin.jvm' version '${Versions().kotlin.kgp}' apply false"))
+        assertFalse(result.contains("kotlin(\"jvm\")"))
+    }
+
+    @Test
+    fun `jvm kotlin root build file uses kotlin plugin syntax`() {
+        val result = BuildGradle().getJvm(Versions(), "gradle.kts")
+
+        assertTrue(result.contains("kotlin(\"jvm\") version(\"${Versions().kotlin.kgp}\") apply false"))
+    }
+
+    @Test
     fun `android root build file omits kotlin android plugin for agp9 built in kotlin`() {
         val result = BuildGradle().getAndroid(Versions(), Versions().di)
 


### PR DESCRIPTION
## Summary

        Automated Codex implementation for cdsap/ProjectGenerator#359: Generated JVM Groovy projects fail to build

        Fixes #359

        ## Verification

        - `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`