### PR TITLE
Prepare release 0.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you need to create small or medium projects (<300 modules), you can use the w
 ## CLI
 ### Install
 ```
-curl -L https://github.com/cdsap/ProjectGenerator/releases/download/v0.6.3/projectGenerator  --output projectGenerator
+curl -L https://github.com/cdsap/ProjectGenerator/releases/download/v0.6.4/projectGenerator  --output projectGenerator
 chmod 0757 projectGenerator
 ```
 
@@ -84,7 +84,7 @@ ProjectGenerator(
 ```
 ### Dependency
 ```
-  implementation("io.github.cdsap:projectgenerator:0.6.3")
+  implementation("io.github.cdsap:projectgenerator:0.6.4")
 ```
 
 # Options

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,7 @@ RUN npm install
 COPY . .
 
 # Download CLI
-RUN curl -L https://github.com/cdsap/ProjectGenerator/releases/download/v0.6.3/projectGenerator \
+RUN curl -L https://github.com/cdsap/ProjectGenerator/releases/download/v0.6.4/projectGenerator \
   --output /usr/local/bin/projectGenerator && \
   chmod 0755 /usr/local/bin/projectGenerator
 

--- a/project-generator/build.gradle.kts
+++ b/project-generator/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.cdsap"
-version = "0.6.3"
+version = "0.6.4"
 
 dependencies {
     implementation(libs.kotlinx.coroutines.core)
@@ -37,7 +37,7 @@ tasks.register<Test>("unitTest") {
 mavenPublishing {
     publishToMavenCentral()
     signAllPublications()
-    coordinates("io.github.cdsap", "projectgenerator", "0.6.3")
+    coordinates("io.github.cdsap", "projectgenerator", "0.6.4")
 
     pom {
         scm {


### PR DESCRIPTION
## Summary

Prepares the `0.6.4` ProjectGenerator release by keeping the Maven coordinates, CLI install instructions, and backend image download target in sync.

## Validation

- Verified all release references now point to `0.6.4`:

```bash
rg -n 'version =|coordinates\(|releases/download/v|io.github.cdsap:projectgenerator:' \
  project-generator/build.gradle.kts README.md backend/Dockerfile
```

- Release preflight was attempted and stopped before publish work because this shell is missing the required release credentials: `USER_NAME`, `central_password`, `key_id`, and `signing_password`.
