### PR TITLE
fix: are projects generated compatible with project isolation?

### DIFF
--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/rootproject/GradleProperties.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/rootproject/GradleProperties.kt
@@ -10,6 +10,7 @@ class GradleProperties {
         org.gradle.jvmargs=-Xmx5g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
         android.useAndroidX=true
         org.gradle.caching=true
+        org.gradle.unsafe.isolated-projects=true
         dependency.analysis.compatibility=NONE
         ${k2usage(versions)}
         ${disableNewDslInAGP9BecauseHilt(versions)}

--- a/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/generator/files/GradlePropertiesTest.kt
+++ b/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/generator/files/GradlePropertiesTest.kt
@@ -27,6 +27,7 @@ class GradlePropertiesTest {
         Assertions.assertTrue(gradleProperties.contains("org.gradle.jvmargs"))
         Assertions.assertTrue(gradleProperties.contains("android.useAndroidX=true"))
         Assertions.assertTrue(gradleProperties.contains("org.gradle.caching=true"))
+        Assertions.assertTrue(gradleProperties.contains("org.gradle.unsafe.isolated-projects=true"))
         Assertions.assertTrue(gradleProperties.contains("ksp.useKSP2=false"))
     }
 


### PR DESCRIPTION
## Summary

        Automated Codex implementation for cdsap/ProjectGenerator#383: Are projects generated compatible with project isolation?

        Fixes #383

        ## Verification

        - `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`