### PR TITLE
fix: when using ksp, use `ksp.project.isolation.enabled=true` to enable

### DIFF
--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/rootproject/GradleProperties.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/rootproject/GradleProperties.kt
@@ -2,30 +2,35 @@ package io.github.cdsap.projectgenerator.generator.rootproject
 
 import io.github.cdsap.projectgenerator.generator.extension.isAgp9
 import io.github.cdsap.projectgenerator.model.DependencyInjection
+import io.github.cdsap.projectgenerator.model.Gradle
 import io.github.cdsap.projectgenerator.model.Processor
 import io.github.cdsap.projectgenerator.model.Versions
 
 class GradleProperties {
-    fun get(versions: Versions) = """
-        org.gradle.jvmargs=-Xmx5g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-        android.useAndroidX=true
-        org.gradle.caching=true
-        dependency.analysis.compatibility=NONE
-        ${k2usage(versions)}
-        ${disableNewDslInAGP9BecauseHilt(versions)}
-    """.trimIndent()
-
-    // Disable K2 for KSP 2.0
-    private fun k2usage(versions: Versions): String {
-        return if (versions.kotlin.kotlinProcessor.processor == Processor.KSP) {
-            "ksp.useKSP2=false"
-        } else ""
+    fun get(versions: Versions, gradle: Gradle = Gradle.latest()): String {
+        return buildList {
+            add("org.gradle.jvmargs=-Xmx5g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8")
+            add("android.useAndroidX=true")
+            add("org.gradle.caching=true")
+            add("dependency.analysis.compatibility=NONE")
+            if (versions.kotlin.kotlinProcessor.processor == Processor.KSP) {
+                // Disable K2 for KSP 2.0
+                add("ksp.useKSP2=false")
+            }
+            if (versions.di == DependencyInjection.HILT && versions.android.agp.isAgp9()) {
+                // Hilt is not compatible with AGP9 new DSL
+                add("android.newDsl=false")
+            }
+            if (isGradle97(gradle)) {
+                // Isolated Projects + KSP IP-compatible task wiring (Gradle 9.7 only)
+                add("org.gradle.unsafe.isolated-projects=true")
+                add("ksp.project.isolation.enabled=true")
+            }
+        }.joinToString("\n")
     }
 
-    // Hilt is not compatible with AGP9, if AGP9 is enabled we need to disable android.newDsl=false
-    private fun disableNewDslInAGP9BecauseHilt(versions: Versions): String {
-        return if (versions.di == DependencyInjection.HILT && versions.android.agp.isAgp9()) {
-            "android.newDsl=false"
-        } else ""
+    private fun isGradle97(gradle: Gradle): Boolean {
+        val parts = gradle.version.split('.')
+        return parts.size >= 2 && parts[0] == "9" && parts[1] == "7"
     }
 }

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/ProjectWriter.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/ProjectWriter.kt
@@ -106,7 +106,7 @@ class ProjectWriter(
     }
 
     private fun createGradleProperties(languages: List<LanguageAttributes>) {
-        val gradleProperties = GradleProperties().get(versions)
+        val gradleProperties = GradleProperties().get(versions, gradle.gradle)
         languages.forEach {
             File("${it.projectName}/gradle.properties").projectFile(gradleProperties)
         }

--- a/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/generator/files/GradlePropertiesTest.kt
+++ b/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/generator/files/GradlePropertiesTest.kt
@@ -3,6 +3,7 @@ package io.github.cdsap.projectgenerator.generator.files
 import io.github.cdsap.projectgenerator.generator.rootproject.GradleProperties
 import io.github.cdsap.projectgenerator.model.DependencyInjection
 import io.github.cdsap.projectgenerator.model.Android
+import io.github.cdsap.projectgenerator.model.Gradle
 import io.github.cdsap.projectgenerator.model.Kotlin
 import io.github.cdsap.projectgenerator.model.KotlinProcessor
 import io.github.cdsap.projectgenerator.model.Processor
@@ -23,7 +24,7 @@ class GradlePropertiesTest {
             android = Android(agp = "8.0.0", hilt = "2.44"),
             project = Project(jdk = "17")
         )
-        val gradleProperties = GradleProperties().get(versions)
+        val gradleProperties = GradleProperties().get(versions, Gradle("9.6.1"))
         Assertions.assertTrue(gradleProperties.contains("org.gradle.jvmargs"))
         Assertions.assertTrue(gradleProperties.contains("android.useAndroidX=true"))
         Assertions.assertTrue(gradleProperties.contains("org.gradle.caching=true"))
@@ -41,7 +42,7 @@ class GradlePropertiesTest {
             android = Android(agp = "8.0.0", hilt = "2.44"),
             project = Project(jdk = "17")
         )
-        val gradleProperties = GradleProperties().get(versions)
+        val gradleProperties = GradleProperties().get(versions, Gradle("9.6.1"))
         Assertions.assertTrue(gradleProperties.contains("org.gradle.jvmargs"))
         Assertions.assertTrue(gradleProperties.contains("android.useAndroidX=true"))
         Assertions.assertTrue(gradleProperties.contains("org.gradle.caching=true"))
@@ -59,7 +60,7 @@ class GradlePropertiesTest {
             android = Android(agp = "8.0.0", hilt = "2.44"),
             project = Project(jdk = "17")
         )
-        val gradleProperties = GradleProperties().get(versions)
+        val gradleProperties = GradleProperties().get(versions, Gradle("9.6.1"))
         Assertions.assertTrue(!gradleProperties.contains("ksp.useKSP2=false"))
     }
 
@@ -70,7 +71,7 @@ class GradlePropertiesTest {
             di = DependencyInjection.HILT
         )
 
-        val gradleProperties = GradleProperties().get(versions)
+        val gradleProperties = GradleProperties().get(versions, Gradle("9.6.1"))
 
         Assertions.assertTrue(gradleProperties.contains("android.newDsl=false"))
     }
@@ -82,8 +83,24 @@ class GradlePropertiesTest {
             di = DependencyInjection.HILT
         )
 
-        val gradleProperties = GradleProperties().get(versions)
+        val gradleProperties = GradleProperties().get(versions, Gradle("9.6.1"))
 
         Assertions.assertFalse(gradleProperties.contains("android.newDsl=false"))
+    }
+
+    @Test
+    fun `includes isolated projects properties for Gradle 9_7`() {
+        val gradleProperties = GradleProperties().get(Versions(), Gradle("9.7.0"))
+
+        Assertions.assertTrue(gradleProperties.contains("org.gradle.unsafe.isolated-projects=true"))
+        Assertions.assertTrue(gradleProperties.contains("ksp.project.isolation.enabled=true"))
+    }
+
+    @Test
+    fun `does not include isolated projects properties for Gradle before 9_7`() {
+        val gradleProperties = GradleProperties().get(Versions(), Gradle("9.6.1"))
+
+        Assertions.assertFalse(gradleProperties.contains("org.gradle.unsafe.isolated-projects=true"))
+        Assertions.assertFalse(gradleProperties.contains("ksp.project.isolation.enabled=true"))
     }
 }


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/ProjectGenerator#396: When using KSP, use `ksp.project.isolation.enabled=true` to enable compatibility with IP

Fixes #396

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `medium`

## Verification

- `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`