### PR TITLE
fix: refactor yaml generation to separate rendering from file output

### DIFF
--- a/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateVersionsYaml.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateVersionsYaml.kt
@@ -12,7 +12,7 @@ class GenerateVersionsYaml {
         if (file.exists()) println("file versions.yaml created ")
     }
 
-    fun render(versions: Versions = Versions(), gradle: Gradle = Gradle.latest()): String {
+    internal fun render(versions: Versions = Versions(), gradle: Gradle = Gradle.latest()): String {
         return """
             |gradle: ${gradle.version}
             |project:
@@ -58,7 +58,7 @@ class GenerateVersionsYaml {
         """.trimMargin()
     }
 
-    fun additionalPlugins(plugins: List<AdditionalPlugin>): String {
+    private fun additionalPlugins(plugins: List<AdditionalPlugin>): String {
         return plugins.joinToString("\n") { plugin ->
             "  - id: ${plugin.id}\n" +
                 "      version: ${plugin.version}\n" +

--- a/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateVersionsYamlTest.kt
+++ b/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateVersionsYamlTest.kt
@@ -1,0 +1,37 @@
+package io.github.cdsap.projectgenerator.cli
+
+import io.github.cdsap.projectgenerator.model.Gradle
+import io.github.cdsap.projectgenerator.model.Versions
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class GenerateVersionsYamlTest {
+
+    @Test
+    fun `render includes key defaults and plugin sections`() {
+        val versions = Versions()
+        val gradle = Gradle.latest()
+        val yaml = GenerateVersionsYaml().render(versions, gradle)
+
+        assertTrue(yaml.contains("gradle: ${gradle.version}"))
+        assertTrue(yaml.contains("develocity: ${versions.project.develocity}"))
+        assertTrue(yaml.contains("develocityUrl: ${versions.project.develocityUrl}"))
+        assertTrue(yaml.contains("jdk: ${versions.project.jdk}"))
+        assertTrue(yaml.contains("di: ${versions.di}"))
+        assertTrue(yaml.contains("kgp: ${versions.kotlin.kgp}"))
+        assertTrue(yaml.contains("ksp: ${versions.kotlin.ksp}"))
+        assertTrue(yaml.contains("processor: ${versions.kotlin.kotlinProcessor.processor}"))
+        assertTrue(yaml.contains("agp: ${versions.android.agp}"))
+        assertTrue(yaml.contains("composeBom: ${versions.android.composeBom}"))
+        assertTrue(yaml.contains("junit4: ${versions.testing.junit4}"))
+        assertTrue(yaml.contains("junit5: ${versions.testing.junit5}"))
+        val settingsPlugin = versions.additionalSettingsPlugins.single()
+        val rootPlugin = versions.additionalBuildGradleRootPlugins.single()
+        assertTrue(yaml.contains("additionalSettingsPlugins:"))
+        assertTrue(yaml.contains("id: ${settingsPlugin.id}"))
+        assertTrue(yaml.contains("version: ${settingsPlugin.version}"))
+        assertTrue(yaml.contains("additionalBuildGradleRootPlugins:"))
+        assertTrue(yaml.contains("id: ${rootPlugin.id}"))
+        assertTrue(yaml.contains("version: ${rootPlugin.version}"))
+    }
+}


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/ProjectGenerator#411: Refactor YAML generation to separate rendering from file output

Fixes #411

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`