### PR TITLE
fix: refactor cli version resolution to isolate configuration mapping

### DIFF
--- a/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt
@@ -71,12 +71,13 @@ class GenerateProjects : CliktCommand(name = "generate-project") {
             throw UsageError("--android-kotlin-multiplatform-library is only available when --type android.")
         }
         val versionsOverride = versionsFile?.let(VersionsParser::fromFile)
-        val versions = getVersions(
+        val versions = resolveVersions(
             fileVersions = versionsOverride,
+            dependencyInjection = dependencyInjection,
             develocityUrl = develocityUrl,
             roomDatabase = roomDatabase,
             kotlinMultiplatformLibrary = kotlinMultiplatformLibrary
-        ).copy(di = dependencyInjection)
+        )
         val develocityEnabled = getDevelocityEnabled(develocity, develocityUrl)
         val language = Language.valueOf(language.uppercase())
         val resolvedProjectName = projectName ?: buildString {
@@ -109,32 +110,32 @@ class GenerateProjects : CliktCommand(name = "generate-project") {
             develocityUrl != null
         }
     }
+}
 
-    private fun getVersions(
-        fileVersions: VersionsFile?,
-        develocityUrl: String?,
-        roomDatabase: Boolean,
-        kotlinMultiplatformLibrary: Boolean
-    ): Versions {
-        val versions = if (fileVersions != null) {
-            fileVersions.resolve()
-        } else {
-            Versions()
-        }
-        var androidConfig = versions.android
-        if (roomDatabase) {
-            androidConfig = androidConfig.copy(roomDatabase = true)
-        }
-        if (kotlinMultiplatformLibrary) {
-            androidConfig = androidConfig.copy(kotlinMultiplatformLibrary = true)
-        }
-        val withAndroidFlags = versions.copy(android = androidConfig)
-        return if (develocityUrl != null) {
-            withAndroidFlags.copy(project = withAndroidFlags.project.copy(develocityUrl = develocityUrl))
-        } else {
-            withAndroidFlags
-        }
-
+internal fun resolveVersions(
+    fileVersions: VersionsFile?,
+    dependencyInjection: DependencyInjection,
+    develocityUrl: String?,
+    roomDatabase: Boolean,
+    kotlinMultiplatformLibrary: Boolean
+): Versions {
+    val versions = if (fileVersions != null) {
+        fileVersions.resolve()
+    } else {
+        Versions()
+    }
+    var androidConfig = versions.android
+    if (roomDatabase) {
+        androidConfig = androidConfig.copy(roomDatabase = true)
+    }
+    if (kotlinMultiplatformLibrary) {
+        androidConfig = androidConfig.copy(kotlinMultiplatformLibrary = true)
+    }
+    val withAndroidFlags = versions.copy(android = androidConfig, di = dependencyInjection)
+    return if (develocityUrl != null) {
+        withAndroidFlags.copy(project = withAndroidFlags.project.copy(develocityUrl = develocityUrl))
+    } else {
+        withAndroidFlags
     }
 }
 

--- a/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
+++ b/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
@@ -2,8 +2,12 @@ package io.github.cdsap.projectgenerator.cli
 
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.core.parse
+import io.github.cdsap.projectgenerator.model.Android
+import io.github.cdsap.projectgenerator.model.DependencyInjection
 import io.github.cdsap.projectgenerator.model.Gradle
 import io.github.cdsap.projectgenerator.model.Language
+import io.github.cdsap.projectgenerator.model.Project
+import io.github.cdsap.projectgenerator.model.Versions
 import io.github.cdsap.projectgenerator.model.VersionsFile
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -11,6 +15,83 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class GenerateProjectsCliTest {
+
+    @Test
+    fun `resolveVersions uses defaults when versions file is absent`() {
+        val resolved = resolveVersions(
+            fileVersions = null,
+            dependencyInjection = DependencyInjection.HILT,
+            develocityUrl = null,
+            roomDatabase = false,
+            kotlinMultiplatformLibrary = false
+        )
+
+        assertEquals(Versions(), resolved)
+    }
+
+    @Test
+    fun `resolveVersions keeps versions-file values when cli overrides are absent`() {
+        val fileVersions = VersionsFile(
+            project = Project(develocityUrl = "https://develocity.example"),
+            android = Android(roomDatabase = true, kotlinMultiplatformLibrary = true),
+            di = DependencyInjection.METRO
+        )
+
+        val resolved = resolveVersions(
+            fileVersions = fileVersions,
+            dependencyInjection = DependencyInjection.HILT,
+            develocityUrl = null,
+            roomDatabase = false,
+            kotlinMultiplatformLibrary = false
+        )
+
+        assertEquals("https://develocity.example", resolved.project.develocityUrl)
+        assertTrue(resolved.android.roomDatabase)
+        assertTrue(resolved.android.kotlinMultiplatformLibrary)
+        assertEquals(DependencyInjection.HILT, resolved.di)
+    }
+
+    @Test
+    fun `resolveVersions applies cli overrides for develocity room kmp and di`() {
+        val fileVersions = VersionsFile(
+            project = Project(develocityUrl = "https://from-file.example"),
+            android = Android(roomDatabase = false, kotlinMultiplatformLibrary = false),
+            di = DependencyInjection.HILT
+        )
+
+        val resolved = resolveVersions(
+            fileVersions = fileVersions,
+            dependencyInjection = DependencyInjection.NONE,
+            develocityUrl = "https://from-cli.example",
+            roomDatabase = true,
+            kotlinMultiplatformLibrary = true
+        )
+
+        assertEquals("https://from-cli.example", resolved.project.develocityUrl)
+        assertTrue(resolved.android.roomDatabase)
+        assertTrue(resolved.android.kotlinMultiplatformLibrary)
+        assertEquals(DependencyInjection.NONE, resolved.di)
+    }
+
+    @Test
+    fun `resolveVersions does not clear file android flags when cli flags are false`() {
+        val fileVersions = VersionsFile(
+            android = Android(roomDatabase = true, kotlinMultiplatformLibrary = true)
+        )
+
+        val resolved = resolveVersions(
+            fileVersions = fileVersions,
+            dependencyInjection = DependencyInjection.METRO,
+            develocityUrl = null,
+            roomDatabase = false,
+            kotlinMultiplatformLibrary = false
+        )
+
+        assertTrue(resolved.android.roomDatabase)
+        assertTrue(resolved.android.kotlinMultiplatformLibrary)
+        assertEquals("", resolved.project.develocityUrl)
+        assertEquals(DependencyInjection.METRO, resolved.di)
+    }
 
     @Test
     fun `room database flag is rejected for jvm type`() {


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/ProjectGenerator#413: Refactor CLI version resolution to isolate configuration mapping

Fixes #413

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`