### PR TITLE
Prepare release 0.6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you need to create small or medium projects (<300 modules), you can use the w
 ## CLI
 ### Install
 ```
-curl -L https://github.com/cdsap/ProjectGenerator/releases/download/v0.6.5/projectGenerator  --output projectGenerator
+curl -L https://github.com/cdsap/ProjectGenerator/releases/download/v0.6.6/projectGenerator  --output projectGenerator
 chmod 0757 projectGenerator
 ```
 
@@ -84,7 +84,7 @@ ProjectGenerator(
 ```
 ### Dependency
 ```
-  implementation("io.github.cdsap:projectgenerator:0.6.5")
+  implementation("io.github.cdsap:projectgenerator:0.6.6")
 ```
 
 # Options

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,7 @@ RUN npm install
 COPY . .
 
 # Download CLI
-RUN curl -L https://github.com/cdsap/ProjectGenerator/releases/download/v0.6.5/projectGenerator \
+RUN curl -L https://github.com/cdsap/ProjectGenerator/releases/download/v0.6.6/projectGenerator \
   --output /usr/local/bin/projectGenerator && \
   chmod 0755 /usr/local/bin/projectGenerator
 

--- a/project-generator/build.gradle.kts
+++ b/project-generator/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.cdsap"
-version = "0.6.5"
+version = "0.6.6"
 
 dependencies {
     implementation(libs.kotlinx.coroutines.core)
@@ -37,7 +37,7 @@ tasks.register<Test>("unitTest") {
 mavenPublishing {
     publishToMavenCentral()
     signAllPublications()
-    coordinates("io.github.cdsap", "projectgenerator", "0.6.5")
+    coordinates("io.github.cdsap", "projectgenerator", "0.6.6")
 
     pom {
         scm {


### PR DESCRIPTION
## Summary

Prepare ProjectGenerator 0.6.6 by updating the release version markers for the Maven publication, README examples, and backend CLI download URL.

## Release checklist

- [x] Version set to 0.6.6 in project-generator/build.gradle.kts
- [x] Maven coordinates set to io.github.cdsap:projectgenerator:0.6.6
- [x] README install and dependency examples point at 0.6.6
- [x] Backend Dockerfile downloads the v0.6.6 CLI asset
- [x] Verified no local or remote v0.6.6 tag existed before preparation

## Validation

- Official ProjectGenerator release preflight passed on clean main for v0.6.6
- Official ProjectGenerator release preflight passed on committed release/v0.6.6
- Both preflight runs used JDK 21 and completed :project-generator:build successfully

Publishing, tagging, Cloud Run deployment, and gh-pages updates remain gated until this PR is merged.