### PR TITLE
fix: refactor module source-set layout to decouple shared writer from an

### DIFF
--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/AndroidModulesWriter.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/AndroidModulesWriter.kt
@@ -36,5 +36,5 @@ class AndroidModulesWriter(
     resources = typeOfStringResources,
     nodes = nodes,
     languages = languages,
-    androidKotlinMultiplatformLibrary = versions.android.kotlinMultiplatformLibrary
+    sourceSetLayout = AndroidModuleSourceSetLayout(versions.android.kotlinMultiplatformLibrary)
 )

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/JvmModulesWriter.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/JvmModulesWriter.kt
@@ -23,5 +23,6 @@ class JvmModulesWriter(
     generateUnitTest = generateUnitTest,
     buildFilesGenerator = BuildFilesGeneratorJvm(),
     nodes = nodes,
-    languages = languages
+    languages = languages,
+    sourceSetLayout = JvmModuleSourceSetLayout
 )

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/ModuleSourceSetLayout.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/ModuleSourceSetLayout.kt
@@ -1,0 +1,25 @@
+package io.github.cdsap.projectgenerator.writer
+
+import io.github.cdsap.projectgenerator.generator.android.AndroidSourceSetLayout
+import io.github.cdsap.projectgenerator.model.ProjectGraph
+
+interface ModuleSourceSetLayout {
+    fun mainKotlinDir(node: ProjectGraph): String
+    fun testKotlinDir(node: ProjectGraph): String
+}
+
+object JvmModuleSourceSetLayout : ModuleSourceSetLayout {
+    override fun mainKotlinDir(node: ProjectGraph): String = "src/main/kotlin"
+
+    override fun testKotlinDir(node: ProjectGraph): String = "src/test/kotlin"
+}
+
+class AndroidModuleSourceSetLayout(
+    private val kotlinMultiplatformLibrary: Boolean
+) : ModuleSourceSetLayout {
+    override fun mainKotlinDir(node: ProjectGraph): String =
+        AndroidSourceSetLayout.kotlinMainSourceDir(node.type, kotlinMultiplatformLibrary)
+
+    override fun testKotlinDir(node: ProjectGraph): String =
+        AndroidSourceSetLayout.kotlinTestSourceDir(node.type, kotlinMultiplatformLibrary)
+}

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/ModulesWriter.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/ModulesWriter.kt
@@ -2,19 +2,15 @@ package io.github.cdsap.projectgenerator.writer
 
 import io.github.cdsap.projectgenerator.model.LanguageAttributes
 import io.github.cdsap.projectgenerator.NameMappings
-import io.github.cdsap.projectgenerator.generator.android.AndroidSourceSetLayout
 import io.github.cdsap.projectgenerator.model.ProjectGraph
 import io.github.cdsap.projectgenerator.model.TypeOfStringResources
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.Executors
 
 abstract class ModulesWrite<MODULE_DEF, DICT>(
     private val classGenerator: ClassGenerator<MODULE_DEF, DICT>,
@@ -26,7 +22,7 @@ abstract class ModulesWrite<MODULE_DEF, DICT>(
     private val resources: TypeOfStringResources? = null,
     private val nodes: List<ProjectGraph>,
     private val languages: List<LanguageAttributes>,
-    private val androidKotlinMultiplatformLibrary: Boolean = false
+    private val sourceSetLayout: ModuleSourceSetLayout = JvmModuleSourceSetLayout
 ) {
     suspend fun write() = coroutineScope {
         val classesDictionary = ConcurrentHashMap<String, CopyOnWriteArrayList<DICT>>()
@@ -67,18 +63,15 @@ abstract class ModulesWrite<MODULE_DEF, DICT>(
         }
     }
 
-
-        private fun createModuleStructure(node: ProjectGraph, lang: LanguageAttributes) {
-        // Create main source directory
+    private fun createModuleStructure(node: ProjectGraph, lang: LanguageAttributes) {
         val layerDir = NameMappings.layerName(node.layer)
         val moduleDir = NameMappings.moduleName(node.id)
         val packageDir = NameMappings.modulePackageName(node.id)
-        val mainSourceDir = AndroidSourceSetLayout.kotlinMainSourceDir(node.type, androidKotlinMultiplatformLibrary)
+        val mainSourceDir = sourceSetLayout.mainKotlinDir(node)
         File("${lang.projectName}/$layerDir/$moduleDir/$mainSourceDir/com/awesomeapp/$packageDir/").mkdirs()
 
-        // Create test directory if needed
         if (generateUnitTest) {
-            val testSourceDir = AndroidSourceSetLayout.kotlinTestSourceDir(node.type, androidKotlinMultiplatformLibrary)
+            val testSourceDir = sourceSetLayout.testKotlinDir(node)
             File("${lang.projectName}/$layerDir/$moduleDir/$testSourceDir/com/awesomeapp/$packageDir/").mkdirs()
         }
     }

--- a/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/writer/ModulesWriterTest.kt
+++ b/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/writer/ModulesWriterTest.kt
@@ -1,13 +1,16 @@
 package io.github.cdsap.projectgenerator.writer
 
+import io.github.cdsap.projectgenerator.NameMappings
 import io.github.cdsap.projectgenerator.model.LanguageAttributes
 import io.github.cdsap.projectgenerator.model.ProjectGraph
 import io.github.cdsap.projectgenerator.model.TypeProject
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.io.File
 import java.nio.file.Path
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
@@ -48,6 +51,38 @@ class ModulesWriterTest {
                 "obtainClassesGenerated and generate must receive the same planned definition"
             )
         }
+    }
+
+    @Test
+    fun `createModuleStructure uses injected source set layout for main and test kotlin dirs`() = runBlocking {
+        val module = ProjectGraph("module_1_1", 1, emptyList(), TypeProject.LIB, 1)
+        val projectRoot = tempDir.resolve("project").toString()
+        val languages = listOf(LanguageAttributes("gradle.kts", projectRoot))
+        val layout = RecordingSourceSetLayout()
+
+        TestModulesWrite(
+            classGenerator = RecordingClassGenerator(),
+            classPlanner = CountingPlanner(),
+            testGenerator = NoOpTestGenerator(),
+            generateUnitTest = true,
+            buildFilesGenerator = NoOpBuildFilesGenerator(),
+            nodes = listOf(module),
+            languages = languages,
+            sourceSetLayout = layout
+        ).write()
+
+        assertEquals(listOf(module), layout.mainKotlinCalls)
+        assertEquals(listOf(module), layout.testKotlinCalls)
+
+        val layerDir = NameMappings.layerName(module.layer)
+        val moduleDir = NameMappings.moduleName(module.id)
+        val packageDir = NameMappings.modulePackageName(module.id)
+        assertTrue(
+            File("$projectRoot/$layerDir/$moduleDir/src/main/kotlin/com/awesomeapp/$packageDir").isDirectory
+        )
+        assertTrue(
+            File("$projectRoot/$layerDir/$moduleDir/src/test/kotlin/com/awesomeapp/$packageDir").isDirectory
+        )
     }
 
     private class ModulePlan(val moduleId: String)
@@ -98,6 +133,21 @@ class ModulesWriterTest {
         ) = Unit
     }
 
+    private class RecordingSourceSetLayout : ModuleSourceSetLayout {
+        val mainKotlinCalls = CopyOnWriteArrayList<ProjectGraph>()
+        val testKotlinCalls = CopyOnWriteArrayList<ProjectGraph>()
+
+        override fun mainKotlinDir(node: ProjectGraph): String {
+            mainKotlinCalls.add(node)
+            return JvmModuleSourceSetLayout.mainKotlinDir(node)
+        }
+
+        override fun testKotlinDir(node: ProjectGraph): String {
+            testKotlinCalls.add(node)
+            return JvmModuleSourceSetLayout.testKotlinDir(node)
+        }
+    }
+
     private class TestModulesWrite(
         classGenerator: ClassGenerator<ModulePlan, String>,
         classPlanner: ModuleClassPlanner<ModulePlan>,
@@ -105,7 +155,8 @@ class ModulesWriterTest {
         generateUnitTest: Boolean,
         buildFilesGenerator: BuildFilesGenerator,
         nodes: List<ProjectGraph>,
-        languages: List<LanguageAttributes>
+        languages: List<LanguageAttributes>,
+        sourceSetLayout: ModuleSourceSetLayout = JvmModuleSourceSetLayout
     ) : ModulesWrite<ModulePlan, String>(
         classGenerator = classGenerator,
         classPlanner = classPlanner,
@@ -115,6 +166,7 @@ class ModulesWriterTest {
         buildFilesGenerator = buildFilesGenerator,
         resources = null,
         nodes = nodes,
-        languages = languages
+        languages = languages,
+        sourceSetLayout = sourceSetLayout
     )
 }


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/ProjectGenerator#420: Refactor module source-set layout to decouple shared writer from Android rules

Fixes #420

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`