### PR TITLE
fix: refactor cli generation options to a request object

### DIFF
--- a/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt
@@ -1,5 +1,6 @@
 package io.github.cdsap.projectgenerator.cli
 
+import com.github.ajalt.clikt.core.UsageError
 import io.github.cdsap.projectgenerator.ProjectGenerator
 import io.github.cdsap.projectgenerator.model.ClassesPerModule
 import io.github.cdsap.projectgenerator.model.DependencyInjection
@@ -63,6 +64,11 @@ data class GenerateProjectRequest(
             roomDatabase: Boolean,
             kotlinMultiplatformLibrary: Boolean
         ): GenerateProjectRequest {
+            validateAndroidOnlyFeatures(
+                typeOfProjectRequested = typeOfProjectRequested,
+                roomDatabase = roomDatabase,
+                kotlinMultiplatformLibrary = kotlinMultiplatformLibrary
+            )
             val resolvedProjectName = resolveProjectName(
                 projectName,
                 typeOfProjectRequested,
@@ -91,6 +97,19 @@ data class GenerateProjectRequest(
                 projectName = resolvedProjectName
             )
         }
+    }
+}
+
+internal fun validateAndroidOnlyFeatures(
+    typeOfProjectRequested: TypeProjectRequested,
+    roomDatabase: Boolean,
+    kotlinMultiplatformLibrary: Boolean
+) {
+    if (typeOfProjectRequested != TypeProjectRequested.ANDROID && roomDatabase) {
+        throw UsageError("--room-database is only available when --type android.")
+    }
+    if (typeOfProjectRequested != TypeProjectRequested.ANDROID && kotlinMultiplatformLibrary) {
+        throw UsageError("--android-kotlin-multiplatform-library is only available when --type android.")
     }
 }
 

--- a/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt
@@ -1,7 +1,6 @@
 package io.github.cdsap.projectgenerator.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.options.*
@@ -56,20 +55,11 @@ class GenerateProjects : CliktCommand(name = "generate-project") {
     private val kotlinMultiplatformLibrary by option("--android-kotlin-multiplatform-library").flag(default = false)
 
     override fun run() {
-        val typeOfProjectRequested = TypeProjectRequested.valueOf(type.uppercase())
-        val shape = Shape.valueOf(shape.uppercase())
-        val dependencyInjection = DependencyInjection.valueOf(di.uppercase())
-        if (typeOfProjectRequested != TypeProjectRequested.ANDROID && roomDatabase) {
-            throw UsageError("--room-database is only available when --type android.")
-        }
-        if (typeOfProjectRequested != TypeProjectRequested.ANDROID && kotlinMultiplatformLibrary) {
-            throw UsageError("--android-kotlin-multiplatform-library is only available when --type android.")
-        }
         GenerateProjectRequest.resolve(
             modules = modules,
-            shape = shape,
+            shape = Shape.valueOf(shape.uppercase()),
             language = Language.valueOf(language.uppercase()),
-            typeOfProjectRequested = typeOfProjectRequested,
+            typeOfProjectRequested = TypeProjectRequested.valueOf(type.uppercase()),
             classesPerModule = ClassesPerModule(
                 ClassesPerModuleType.valueOf(classesModuleType.uppercase()),
                 classesModule
@@ -83,7 +73,7 @@ class GenerateProjects : CliktCommand(name = "generate-project") {
             versionsFile = versionsFile?.let(VersionsParser::fromFile),
             outputDir = outputDir,
             projectName = projectName,
-            dependencyInjection = dependencyInjection,
+            dependencyInjection = DependencyInjection.valueOf(di.uppercase()),
             roomDatabase = roomDatabase,
             kotlinMultiplatformLibrary = kotlinMultiplatformLibrary
         ).toProjectGenerator().write()

--- a/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
+++ b/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
@@ -130,6 +130,60 @@ class GenerateProjectsCliTest {
     }
 
     @Test
+    fun `resolve rejects room database for jvm type`() {
+        val error = assertThrows<UsageError> {
+            GenerateProjectRequest.resolve(
+                modules = 6,
+                shape = Shape.RECTANGLE,
+                language = Language.KTS,
+                typeOfProjectRequested = TypeProjectRequested.JVM,
+                classesPerModule = ClassesPerModule(ClassesPerModuleType.FIXED, 10),
+                typeOfStringResources = TypeOfStringResources.NORMAL,
+                layers = 5,
+                generateUnitTest = false,
+                cliGradle = null,
+                develocityFlag = false,
+                develocityUrl = null,
+                versionsFile = null,
+                outputDir = null,
+                projectName = null,
+                dependencyInjection = DependencyInjection.HILT,
+                roomDatabase = true,
+                kotlinMultiplatformLibrary = false
+            )
+        }
+        assertTrue(error.message?.contains("--room-database is only available when --type android.") == true)
+    }
+
+    @Test
+    fun `resolve rejects android kotlin multiplatform library for jvm type`() {
+        val error = assertThrows<UsageError> {
+            GenerateProjectRequest.resolve(
+                modules = 6,
+                shape = Shape.RECTANGLE,
+                language = Language.KTS,
+                typeOfProjectRequested = TypeProjectRequested.JVM,
+                classesPerModule = ClassesPerModule(ClassesPerModuleType.FIXED, 10),
+                typeOfStringResources = TypeOfStringResources.NORMAL,
+                layers = 5,
+                generateUnitTest = false,
+                cliGradle = null,
+                develocityFlag = false,
+                develocityUrl = null,
+                versionsFile = null,
+                outputDir = null,
+                projectName = null,
+                dependencyInjection = DependencyInjection.HILT,
+                roomDatabase = false,
+                kotlinMultiplatformLibrary = true
+            )
+        }
+        assertTrue(
+            error.message?.contains("--android-kotlin-multiplatform-library is only available when --type android.") == true
+        )
+    }
+
+    @Test
     fun `classes module lower than minimum is rejected`() {
         val error = assertThrows<UsageError> {
             GenerateProjects().parse(


### PR DESCRIPTION
## Summary

### Problem

`cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt` mixes Clikt option declarations with application-level generation mapping: enum conversion and Android-only validation at lines 63-72, versions/Gradle/path resolution at lines 73-100, and helper functions at lines 115-158. The tests in `cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt` already exercise pieces of that mapping directly, which shows this logic is more than command-line parsing.

### Why this matters

As new generation flags are added, `GenerateProjects.run()` becomes the place where transport concerns, validation rules, defaults, and generator construction all change together. That raises the chance of precedence regressions such as CLI flags accidentally clearing values from `--versions-file`, and makes it harder to test generation-request behavior without instantiating a Clikt command.

### Proposed change

Introduce a small internal CLI-side request/config type, for example `GenerateProjectRequest`, plus a mapper from parsed `GenerateProjects` options to that type. Move `resolveVersions`, `resolveGradle`, `resolveProjectRootPath`, project-name derivation, and Android-only feature validation behind that request-building boundary. Keep `GenerateProjects.run()` responsible for parsing and invoking `ProjectGenerator(...).write()` only.

### Notes

Clean architecture lens: `GenerateProjects` is a delivery adapter, while the resolved generation request is the CLI application boundary. Extracting that boundary keeps domain models in `project-generator` unchanged while making CLI policy explicit and easier to test.

Fixes #424

## Changes

- `cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt`
- `cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt`
- `cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt`

## Verification

- `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`
