### PR TITLE
fix: refactor cli version resolution to isolate configuration merging

### DIFF
--- a/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt
@@ -81,7 +81,7 @@ data class GenerateProjectRequest(
                 language = language,
                 typeOfProjectRequested = typeOfProjectRequested,
                 classesPerModule = classesPerModule,
-                versions = resolveVersions(
+                versions = VersionsResolver.resolve(
                     fileVersions = versionsFile,
                     dependencyInjection = dependencyInjection,
                     develocityUrl = develocityUrl,
@@ -129,33 +129,6 @@ internal fun resolveProjectName(
 
 internal fun resolveDevelocityEnabled(develocity: Boolean, develocityUrl: String?): Boolean {
     return develocity || develocityUrl != null
-}
-
-internal fun resolveVersions(
-    fileVersions: VersionsFile?,
-    dependencyInjection: DependencyInjection,
-    develocityUrl: String?,
-    roomDatabase: Boolean,
-    kotlinMultiplatformLibrary: Boolean
-): Versions {
-    val versions = if (fileVersions != null) {
-        fileVersions.resolve()
-    } else {
-        Versions()
-    }
-    var androidConfig = versions.android
-    if (roomDatabase) {
-        androidConfig = androidConfig.copy(roomDatabase = true)
-    }
-    if (kotlinMultiplatformLibrary) {
-        androidConfig = androidConfig.copy(kotlinMultiplatformLibrary = true)
-    }
-    val withAndroidFlags = versions.copy(android = androidConfig, di = dependencyInjection)
-    return if (develocityUrl != null) {
-        withAndroidFlags.copy(project = withAndroidFlags.project.copy(develocityUrl = develocityUrl))
-    } else {
-        withAndroidFlags
-    }
 }
 
 internal fun resolveProjectRootPath(outputDir: String?, language: Language, projectName: String): String {

--- a/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolver.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolver.kt
@@ -1,0 +1,35 @@
+package io.github.cdsap.projectgenerator.cli
+
+import io.github.cdsap.projectgenerator.model.DependencyInjection
+import io.github.cdsap.projectgenerator.model.Versions
+import io.github.cdsap.projectgenerator.model.VersionsFile
+
+object VersionsResolver {
+    fun resolve(
+        fileVersions: VersionsFile?,
+        dependencyInjection: DependencyInjection,
+        develocityUrl: String?,
+        roomDatabase: Boolean,
+        kotlinMultiplatformLibrary: Boolean
+    ): Versions {
+        val versions = if (fileVersions != null) {
+            fileVersions.resolve()
+        } else {
+            Versions()
+        }
+        // CLI flags only enable features; false must not clear values from --versions-file.
+        var androidConfig = versions.android
+        if (roomDatabase) {
+            androidConfig = androidConfig.copy(roomDatabase = true)
+        }
+        if (kotlinMultiplatformLibrary) {
+            androidConfig = androidConfig.copy(kotlinMultiplatformLibrary = true)
+        }
+        val withAndroidFlags = versions.copy(android = androidConfig, di = dependencyInjection)
+        return if (develocityUrl != null) {
+            withAndroidFlags.copy(project = withAndroidFlags.project.copy(develocityUrl = develocityUrl))
+        } else {
+            withAndroidFlags
+        }
+    }
+}

--- a/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
+++ b/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
@@ -2,17 +2,14 @@ package io.github.cdsap.projectgenerator.cli
 
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.core.parse
-import io.github.cdsap.projectgenerator.model.Android
 import io.github.cdsap.projectgenerator.model.ClassesPerModule
 import io.github.cdsap.projectgenerator.model.ClassesPerModuleType
 import io.github.cdsap.projectgenerator.model.DependencyInjection
 import io.github.cdsap.projectgenerator.model.Gradle
 import io.github.cdsap.projectgenerator.model.Language
-import io.github.cdsap.projectgenerator.model.Project
 import io.github.cdsap.projectgenerator.model.Shape
 import io.github.cdsap.projectgenerator.model.TypeOfStringResources
 import io.github.cdsap.projectgenerator.model.TypeProjectRequested
-import io.github.cdsap.projectgenerator.model.Versions
 import io.github.cdsap.projectgenerator.model.VersionsFile
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -21,83 +18,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class GenerateProjectsCliTest {
-
-    @Test
-    fun `resolveVersions uses defaults when versions file is absent`() {
-        val resolved = resolveVersions(
-            fileVersions = null,
-            dependencyInjection = DependencyInjection.HILT,
-            develocityUrl = null,
-            roomDatabase = false,
-            kotlinMultiplatformLibrary = false
-        )
-
-        assertEquals(Versions(), resolved)
-    }
-
-    @Test
-    fun `resolveVersions keeps versions-file values when cli overrides are absent`() {
-        val fileVersions = VersionsFile(
-            project = Project(develocityUrl = "https://develocity.example"),
-            android = Android(roomDatabase = true, kotlinMultiplatformLibrary = true),
-            di = DependencyInjection.METRO
-        )
-
-        val resolved = resolveVersions(
-            fileVersions = fileVersions,
-            dependencyInjection = DependencyInjection.HILT,
-            develocityUrl = null,
-            roomDatabase = false,
-            kotlinMultiplatformLibrary = false
-        )
-
-        assertEquals("https://develocity.example", resolved.project.develocityUrl)
-        assertTrue(resolved.android.roomDatabase)
-        assertTrue(resolved.android.kotlinMultiplatformLibrary)
-        assertEquals(DependencyInjection.HILT, resolved.di)
-    }
-
-    @Test
-    fun `resolveVersions applies cli overrides for develocity room kmp and di`() {
-        val fileVersions = VersionsFile(
-            project = Project(develocityUrl = "https://from-file.example"),
-            android = Android(roomDatabase = false, kotlinMultiplatformLibrary = false),
-            di = DependencyInjection.HILT
-        )
-
-        val resolved = resolveVersions(
-            fileVersions = fileVersions,
-            dependencyInjection = DependencyInjection.NONE,
-            develocityUrl = "https://from-cli.example",
-            roomDatabase = true,
-            kotlinMultiplatformLibrary = true
-        )
-
-        assertEquals("https://from-cli.example", resolved.project.develocityUrl)
-        assertTrue(resolved.android.roomDatabase)
-        assertTrue(resolved.android.kotlinMultiplatformLibrary)
-        assertEquals(DependencyInjection.NONE, resolved.di)
-    }
-
-    @Test
-    fun `resolveVersions does not clear file android flags when cli flags are false`() {
-        val fileVersions = VersionsFile(
-            android = Android(roomDatabase = true, kotlinMultiplatformLibrary = true)
-        )
-
-        val resolved = resolveVersions(
-            fileVersions = fileVersions,
-            dependencyInjection = DependencyInjection.METRO,
-            develocityUrl = null,
-            roomDatabase = false,
-            kotlinMultiplatformLibrary = false
-        )
-
-        assertTrue(resolved.android.roomDatabase)
-        assertTrue(resolved.android.kotlinMultiplatformLibrary)
-        assertEquals("", resolved.project.develocityUrl)
-        assertEquals(DependencyInjection.METRO, resolved.di)
-    }
 
     @Test
     fun `room database flag is rejected for jvm type`() {

--- a/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolverTest.kt
+++ b/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolverTest.kt
@@ -1,0 +1,90 @@
+package io.github.cdsap.projectgenerator.cli
+
+import io.github.cdsap.projectgenerator.model.Android
+import io.github.cdsap.projectgenerator.model.DependencyInjection
+import io.github.cdsap.projectgenerator.model.Project
+import io.github.cdsap.projectgenerator.model.Versions
+import io.github.cdsap.projectgenerator.model.VersionsFile
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class VersionsResolverTest {
+
+    @Test
+    fun `resolve uses defaults when versions file is absent`() {
+        val resolved = VersionsResolver.resolve(
+            fileVersions = null,
+            dependencyInjection = DependencyInjection.HILT,
+            develocityUrl = null,
+            roomDatabase = false,
+            kotlinMultiplatformLibrary = false
+        )
+
+        assertEquals(Versions(), resolved)
+    }
+
+    @Test
+    fun `resolve keeps versions-file values when cli overrides are absent`() {
+        val fileVersions = VersionsFile(
+            project = Project(develocityUrl = "https://develocity.example"),
+            android = Android(roomDatabase = true, kotlinMultiplatformLibrary = true),
+            di = DependencyInjection.METRO
+        )
+
+        val resolved = VersionsResolver.resolve(
+            fileVersions = fileVersions,
+            dependencyInjection = DependencyInjection.HILT,
+            develocityUrl = null,
+            roomDatabase = false,
+            kotlinMultiplatformLibrary = false
+        )
+
+        assertEquals("https://develocity.example", resolved.project.develocityUrl)
+        assertTrue(resolved.android.roomDatabase)
+        assertTrue(resolved.android.kotlinMultiplatformLibrary)
+        assertEquals(DependencyInjection.HILT, resolved.di)
+    }
+
+    @Test
+    fun `resolve applies cli overrides for develocity room kmp and di`() {
+        val fileVersions = VersionsFile(
+            project = Project(develocityUrl = "https://from-file.example"),
+            android = Android(roomDatabase = false, kotlinMultiplatformLibrary = false),
+            di = DependencyInjection.HILT
+        )
+
+        val resolved = VersionsResolver.resolve(
+            fileVersions = fileVersions,
+            dependencyInjection = DependencyInjection.NONE,
+            develocityUrl = "https://from-cli.example",
+            roomDatabase = true,
+            kotlinMultiplatformLibrary = true
+        )
+
+        assertEquals("https://from-cli.example", resolved.project.develocityUrl)
+        assertTrue(resolved.android.roomDatabase)
+        assertTrue(resolved.android.kotlinMultiplatformLibrary)
+        assertEquals(DependencyInjection.NONE, resolved.di)
+    }
+
+    @Test
+    fun `resolve does not clear file android flags when cli flags are false`() {
+        val fileVersions = VersionsFile(
+            android = Android(roomDatabase = true, kotlinMultiplatformLibrary = true)
+        )
+
+        val resolved = VersionsResolver.resolve(
+            fileVersions = fileVersions,
+            dependencyInjection = DependencyInjection.METRO,
+            develocityUrl = null,
+            roomDatabase = false,
+            kotlinMultiplatformLibrary = false
+        )
+
+        assertTrue(resolved.android.roomDatabase)
+        assertTrue(resolved.android.kotlinMultiplatformLibrary)
+        assertEquals("", resolved.project.develocityUrl)
+        assertEquals(DependencyInjection.METRO, resolved.di)
+    }
+}


### PR DESCRIPTION
## Summary

### Problem

`cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt` currently mixes Clikt command parsing with generation configuration policy: `GenerateProjects.run` reads `VersionsParser` output and applies CLI overrides at lines 73-80, while the merge rules live as a top-level `resolveVersions` helper in the same CLI entrypoint file at lines 115-140. The core `VersionsFile.resolve` model behavior already lives separately in `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/model/VersionsFile.kt` lines 13-21, but CLI-specific override rules are still coupled to the command class file.

### Why this matters

Every new version-related CLI flag will tend to grow `Main.kt`, making it harder to distinguish adapter concerns (option parsing and UsageError validation) from application behavior (how file defaults and CLI overrides combine). The current tests cover the behavior, but they are anchored to the command entrypoint instead of a focused resolver boundary.

### Proposed change

Add a small `VersionsResolver` or `GenerationVersionsResolver` in the CLI package that owns the existing `resolveVersions` logic. `GenerateProjects.run` should delegate to it after parsing options, and the current `resolveVersions` tests in `GenerateProjectsCliTest` can move or retarget to the resolver while preserving the existing assertions and behavior.

### Notes

Clean architecture lens: keep the CLI command as an adapter that translates command-line input, and isolate the application policy for composing generation versions. This is intentionally a small extraction, not a rewrite of the project generation API.

Fixes #428

## Changes

- `cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt`
- `cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolver.kt`
- `cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt`
- `cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolverTest.kt`

## Verification

- `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`
