### PR TITLE
fix: refactor cli version overrides to explicit options object

### DIFF
--- a/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt
@@ -3,7 +3,6 @@ package io.github.cdsap.projectgenerator.cli
 import com.github.ajalt.clikt.core.UsageError
 import io.github.cdsap.projectgenerator.ProjectGenerator
 import io.github.cdsap.projectgenerator.model.ClassesPerModule
-import io.github.cdsap.projectgenerator.model.DependencyInjection
 import io.github.cdsap.projectgenerator.model.Gradle
 import io.github.cdsap.projectgenerator.model.Language
 import io.github.cdsap.projectgenerator.model.Shape
@@ -56,18 +55,15 @@ data class GenerateProjectRequest(
             generateUnitTest: Boolean,
             cliGradle: String?,
             develocityFlag: Boolean,
-            develocityUrl: String?,
             versionsFile: VersionsFile?,
             outputDir: String?,
             projectName: String?,
-            dependencyInjection: DependencyInjection,
-            roomDatabase: Boolean,
-            kotlinMultiplatformLibrary: Boolean
+            versionsOverrides: VersionsOverrides
         ): GenerateProjectRequest {
             validateAndroidOnlyFeatures(
                 typeOfProjectRequested = typeOfProjectRequested,
-                roomDatabase = roomDatabase,
-                kotlinMultiplatformLibrary = kotlinMultiplatformLibrary
+                roomDatabase = versionsOverrides.roomDatabase,
+                kotlinMultiplatformLibrary = versionsOverrides.kotlinMultiplatformLibrary
             )
             val resolvedProjectName = resolveProjectName(
                 projectName,
@@ -83,17 +79,14 @@ data class GenerateProjectRequest(
                 classesPerModule = classesPerModule,
                 versions = VersionsResolver.resolve(
                     fileVersions = versionsFile,
-                    dependencyInjection = dependencyInjection,
-                    develocityUrl = develocityUrl,
-                    roomDatabase = roomDatabase,
-                    kotlinMultiplatformLibrary = kotlinMultiplatformLibrary
+                    overrides = versionsOverrides
                 ),
                 typeOfStringResources = typeOfStringResources,
                 layers = layers,
                 generateUnitTest = generateUnitTest,
                 gradle = resolveGradle(cliGradle, versionsFile),
                 projectRootPath = resolveProjectRootPath(outputDir, language, resolvedProjectName),
-                develocity = resolveDevelocityEnabled(develocityFlag, develocityUrl),
+                develocity = resolveDevelocityEnabled(develocityFlag, versionsOverrides.develocityUrl),
                 projectName = resolvedProjectName
             )
         }

--- a/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt
@@ -69,13 +69,15 @@ class GenerateProjects : CliktCommand(name = "generate-project") {
             generateUnitTest = generateUnitTest,
             cliGradle = gradle,
             develocityFlag = develocity,
-            develocityUrl = develocityUrl,
             versionsFile = versionsFile?.let(VersionsParser::fromFile),
             outputDir = outputDir,
             projectName = projectName,
-            dependencyInjection = DependencyInjection.valueOf(di.uppercase()),
-            roomDatabase = roomDatabase,
-            kotlinMultiplatformLibrary = kotlinMultiplatformLibrary
+            versionsOverrides = VersionsOverrides(
+                dependencyInjection = DependencyInjection.valueOf(di.uppercase()),
+                develocityUrl = develocityUrl,
+                roomDatabase = roomDatabase,
+                kotlinMultiplatformLibrary = kotlinMultiplatformLibrary
+            )
         ).toProjectGenerator().write()
     }
 }

--- a/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolver.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolver.kt
@@ -4,32 +4,37 @@ import io.github.cdsap.projectgenerator.model.DependencyInjection
 import io.github.cdsap.projectgenerator.model.Versions
 import io.github.cdsap.projectgenerator.model.VersionsFile
 
-object VersionsResolver {
-    fun resolve(
-        fileVersions: VersionsFile?,
-        dependencyInjection: DependencyInjection,
-        develocityUrl: String?,
-        roomDatabase: Boolean,
-        kotlinMultiplatformLibrary: Boolean
-    ): Versions {
-        val versions = if (fileVersions != null) {
-            fileVersions.resolve()
-        } else {
-            Versions()
-        }
-        // CLI flags only enable features; false must not clear values from --versions-file.
-        var androidConfig = versions.android
+// CLI-only: false / null means "do not override" so --versions-file values stay intact.
+// dependencyInjection is always taken from the CLI (Clikt always supplies a value).
+data class VersionsOverrides(
+    val dependencyInjection: DependencyInjection,
+    val develocityUrl: String?,
+    val roomDatabase: Boolean,
+    val kotlinMultiplatformLibrary: Boolean
+) {
+    fun applyTo(base: Versions): Versions {
+        var androidConfig = base.android
         if (roomDatabase) {
             androidConfig = androidConfig.copy(roomDatabase = true)
         }
         if (kotlinMultiplatformLibrary) {
             androidConfig = androidConfig.copy(kotlinMultiplatformLibrary = true)
         }
-        val withAndroidFlags = versions.copy(android = androidConfig, di = dependencyInjection)
+        val withAndroidFlags = base.copy(android = androidConfig, di = dependencyInjection)
         return if (develocityUrl != null) {
             withAndroidFlags.copy(project = withAndroidFlags.project.copy(develocityUrl = develocityUrl))
         } else {
             withAndroidFlags
         }
+    }
+}
+
+object VersionsResolver {
+    fun resolve(
+        fileVersions: VersionsFile?,
+        overrides: VersionsOverrides
+    ): Versions {
+        val base = fileVersions?.resolve() ?: Versions()
+        return overrides.applyTo(base)
     }
 }

--- a/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
+++ b/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
@@ -63,13 +63,15 @@ class GenerateProjectsCliTest {
                 generateUnitTest = false,
                 cliGradle = null,
                 develocityFlag = false,
-                develocityUrl = null,
                 versionsFile = null,
                 outputDir = null,
                 projectName = null,
-                dependencyInjection = DependencyInjection.HILT,
-                roomDatabase = true,
-                kotlinMultiplatformLibrary = false
+                versionsOverrides = VersionsOverrides(
+                    dependencyInjection = DependencyInjection.HILT,
+                    develocityUrl = null,
+                    roomDatabase = true,
+                    kotlinMultiplatformLibrary = false
+                )
             )
         }
         assertTrue(error.message?.contains("--room-database is only available when --type android.") == true)
@@ -89,13 +91,15 @@ class GenerateProjectsCliTest {
                 generateUnitTest = false,
                 cliGradle = null,
                 develocityFlag = false,
-                develocityUrl = null,
                 versionsFile = null,
                 outputDir = null,
                 projectName = null,
-                dependencyInjection = DependencyInjection.HILT,
-                roomDatabase = false,
-                kotlinMultiplatformLibrary = true
+                versionsOverrides = VersionsOverrides(
+                    dependencyInjection = DependencyInjection.HILT,
+                    develocityUrl = null,
+                    roomDatabase = false,
+                    kotlinMultiplatformLibrary = true
+                )
             )
         }
         assertTrue(
@@ -187,13 +191,15 @@ class GenerateProjectsCliTest {
             generateUnitTest = false,
             cliGradle = null,
             develocityFlag = false,
-            develocityUrl = "https://develocity.example",
             versionsFile = null,
             outputDir = null,
             projectName = "named",
-            dependencyInjection = DependencyInjection.HILT,
-            roomDatabase = false,
-            kotlinMultiplatformLibrary = false
+            versionsOverrides = VersionsOverrides(
+                dependencyInjection = DependencyInjection.HILT,
+                develocityUrl = "https://develocity.example",
+                roomDatabase = false,
+                kotlinMultiplatformLibrary = false
+            )
         )
 
         assertTrue(request.develocity)
@@ -218,13 +224,15 @@ class GenerateProjectsCliTest {
             generateUnitTest = false,
             cliGradle = null,
             develocityFlag = false,
-            develocityUrl = null,
             versionsFile = null,
             outputDir = null,
             projectName = null,
-            dependencyInjection = DependencyInjection.HILT,
-            roomDatabase = false,
-            kotlinMultiplatformLibrary = false
+            versionsOverrides = VersionsOverrides(
+                dependencyInjection = DependencyInjection.HILT,
+                develocityUrl = null,
+                roomDatabase = false,
+                kotlinMultiplatformLibrary = false
+            )
         )
 
         assertEquals("jvmTriangle12modules", request.projectName)

--- a/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolverTest.kt
+++ b/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolverTest.kt
@@ -15,30 +15,31 @@ class VersionsResolverTest {
     fun `resolve uses defaults when versions file is absent`() {
         val resolved = VersionsResolver.resolve(
             fileVersions = null,
-            dependencyInjection = DependencyInjection.HILT,
-            develocityUrl = null,
-            roomDatabase = false,
-            kotlinMultiplatformLibrary = false
+            overrides = VersionsOverrides(
+                dependencyInjection = DependencyInjection.HILT,
+                develocityUrl = null,
+                roomDatabase = false,
+                kotlinMultiplatformLibrary = false
+            )
         )
 
         assertEquals(Versions(), resolved)
     }
 
     @Test
-    fun `resolve keeps versions-file values when cli overrides are absent`() {
-        val fileVersions = VersionsFile(
+    fun `applyTo keeps versions-file values when cli overrides are absent`() {
+        val base = VersionsFile(
             project = Project(develocityUrl = "https://develocity.example"),
             android = Android(roomDatabase = true, kotlinMultiplatformLibrary = true),
             di = DependencyInjection.METRO
-        )
+        ).resolve()
 
-        val resolved = VersionsResolver.resolve(
-            fileVersions = fileVersions,
+        val resolved = VersionsOverrides(
             dependencyInjection = DependencyInjection.HILT,
             develocityUrl = null,
             roomDatabase = false,
             kotlinMultiplatformLibrary = false
-        )
+        ).applyTo(base)
 
         assertEquals("https://develocity.example", resolved.project.develocityUrl)
         assertTrue(resolved.android.roomDatabase)
@@ -47,20 +48,19 @@ class VersionsResolverTest {
     }
 
     @Test
-    fun `resolve applies cli overrides for develocity room kmp and di`() {
-        val fileVersions = VersionsFile(
+    fun `applyTo applies cli overrides for develocity room kmp and di`() {
+        val base = VersionsFile(
             project = Project(develocityUrl = "https://from-file.example"),
             android = Android(roomDatabase = false, kotlinMultiplatformLibrary = false),
             di = DependencyInjection.HILT
-        )
+        ).resolve()
 
-        val resolved = VersionsResolver.resolve(
-            fileVersions = fileVersions,
+        val resolved = VersionsOverrides(
             dependencyInjection = DependencyInjection.NONE,
             develocityUrl = "https://from-cli.example",
             roomDatabase = true,
             kotlinMultiplatformLibrary = true
-        )
+        ).applyTo(base)
 
         assertEquals("https://from-cli.example", resolved.project.develocityUrl)
         assertTrue(resolved.android.roomDatabase)
@@ -69,18 +69,17 @@ class VersionsResolverTest {
     }
 
     @Test
-    fun `resolve does not clear file android flags when cli flags are false`() {
-        val fileVersions = VersionsFile(
+    fun `applyTo does not clear file android flags when cli flags are false`() {
+        val base = VersionsFile(
             android = Android(roomDatabase = true, kotlinMultiplatformLibrary = true)
-        )
+        ).resolve()
 
-        val resolved = VersionsResolver.resolve(
-            fileVersions = fileVersions,
+        val resolved = VersionsOverrides(
             dependencyInjection = DependencyInjection.METRO,
             develocityUrl = null,
             roomDatabase = false,
             kotlinMultiplatformLibrary = false
-        )
+        ).applyTo(base)
 
         assertTrue(resolved.android.roomDatabase)
         assertTrue(resolved.android.kotlinMultiplatformLibrary)


### PR DESCRIPTION
## Summary

### Problem

`cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt:73-80` passes several independent CLI override values into `resolveVersions`, and `Main.kt:115-140` applies those booleans and nullable strings directly while also resolving file-backed defaults. The behavior is already tested in `cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt:19-94`, but the boundary between parsed CLI input and domain `Versions` composition is implicit.

### Why this matters

Each new override flag has to expand the `resolveVersions` parameter list and duplicate call-site wiring in tests. That makes precedence rules harder to scan and easier to break, especially because false boolean flags intentionally mean 'do not override' rather than 'set false'.

### Proposed change

Introduce a small internal CLI-only data class, for example `VersionsOverrides`, containing `dependencyInjection`, `develocityUrl`, `roomDatabase`, and `kotlinMultiplatformLibrary`, with an `applyTo(base: Versions): Versions` method. `GenerateProjects.run` should build this object from parsed Clikt values, resolve the base from `VersionsFile?.resolve() ?: Versions()`, then apply the overrides. Keep `VersionsFile.resolve` in the model unchanged so YAML parsing semantics stay separate from command-line precedence.

### Notes

From a clean architecture lens, this keeps the CLI adapter responsible for translating transport-level flags into one application-level override object, while the core `VersionsFile` model remains focused on YAML default resolution.

Fixes #437

## Changes

- `cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt`
- `cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt`
- `cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolver.kt`
- `cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt`
- `cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolverTest.kt`

## Verification

- `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`
