### PR TITLE
fix: refactor module generation ports to clarify ownership

### DIFF
--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/ModuleGenerationPorts.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/ModuleGenerationPorts.kt
@@ -1,0 +1,43 @@
+package io.github.cdsap.projectgenerator.generator
+
+import io.github.cdsap.projectgenerator.model.LanguageAttributes
+import io.github.cdsap.projectgenerator.model.ProjectGraph
+import io.github.cdsap.projectgenerator.model.TypeOfStringResources
+import java.util.concurrent.CopyOnWriteArrayList
+
+interface ModuleClassPlanner<MODULE_DEF> {
+    fun planModuleClasses(node: ProjectGraph): MODULE_DEF
+}
+
+interface ClassGenerator<MODULE_DEF, DICT> {
+    fun generate(
+        moduleDefinition: MODULE_DEF,
+        projectName: String,
+        a: MutableMap<String, CopyOnWriteArrayList<DICT>>
+    )
+
+    fun obtainClassesGenerated(
+        moduleDefinition: MODULE_DEF,
+        classesDictionary: MutableMap<String, CopyOnWriteArrayList<DICT>>
+    ): MutableMap<String, CopyOnWriteArrayList<DICT>>
+}
+
+interface TestGenerator<MODULE_DEF, DICT> {
+    fun generate(
+        moduleDefinition: MODULE_DEF,
+        projectName: String,
+        classesDictionary: MutableMap<String, CopyOnWriteArrayList<DICT>>
+    )
+}
+
+interface BuildFilesGenerator {
+    fun generateBuildFiles(node: ProjectGraph, lang: LanguageAttributes, generateUnitTests: Boolean)
+}
+
+interface ResourceGeneratorA<DICT> {
+    fun generate(
+        node: ProjectGraph, lang: LanguageAttributes,
+        typeOfStringResources: TypeOfStringResources,
+        classesDictionary: MutableMap<String, CopyOnWriteArrayList<DICT>>
+    )
+}

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/buildfiles/BuildFilesGeneratorAndroid.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/buildfiles/BuildFilesGeneratorAndroid.kt
@@ -1,6 +1,6 @@
 package io.github.cdsap.projectgenerator.generator.buildfiles
 
-import io.github.cdsap.projectgenerator.writer.BuildFilesGenerator
+import io.github.cdsap.projectgenerator.generator.BuildFilesGenerator
 import io.github.cdsap.projectgenerator.generator.toml.AndroidToml
 import io.github.cdsap.projectgenerator.model.LanguageAttributes
 import io.github.cdsap.projectgenerator.model.ProjectGraph

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/buildfiles/BuildFilesGeneratorJvm.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/buildfiles/BuildFilesGeneratorJvm.kt
@@ -1,6 +1,6 @@
 package io.github.cdsap.projectgenerator.generator.buildfiles
 
-import io.github.cdsap.projectgenerator.writer.BuildFilesGenerator
+import io.github.cdsap.projectgenerator.generator.BuildFilesGenerator
 import io.github.cdsap.projectgenerator.model.LanguageAttributes
 import io.github.cdsap.projectgenerator.model.ProjectGraph
 import io.github.cdsap.projectgenerator.model.TypeProject

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/classes/ClassGeneratorAndroid.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/classes/ClassGeneratorAndroid.kt
@@ -4,7 +4,7 @@ import io.github.cdsap.projectgenerator.generator.GeneratedModuleLayout
 import io.github.cdsap.projectgenerator.generator.android.AndroidSourceSetLayout
 import io.github.cdsap.projectgenerator.model.*
 import io.github.cdsap.projectgenerator.NameMappings
-import io.github.cdsap.projectgenerator.writer.ClassGenerator
+import io.github.cdsap.projectgenerator.generator.ClassGenerator
 import java.io.File
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.text.appendLine

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/classes/ClassGeneratorAndroidLegacy.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/classes/ClassGeneratorAndroidLegacy.kt
@@ -3,7 +3,7 @@ package io.github.cdsap.projectgenerator.generator.classes
 import io.github.cdsap.projectgenerator.generator.android.AndroidSourceSetLayout
 import io.github.cdsap.projectgenerator.model.*
 import io.github.cdsap.projectgenerator.NameMappings
-import io.github.cdsap.projectgenerator.writer.ClassGenerator
+import io.github.cdsap.projectgenerator.generator.ClassGenerator
 import java.io.File
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.text.appendLine

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/classes/ClassGeneratorJvm.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/classes/ClassGeneratorJvm.kt
@@ -2,7 +2,7 @@ package io.github.cdsap.projectgenerator.generator.classes
 
 import io.github.cdsap.projectgenerator.model.*
 import io.github.cdsap.projectgenerator.NameMappings
-import io.github.cdsap.projectgenerator.writer.ClassGenerator
+import io.github.cdsap.projectgenerator.generator.ClassGenerator
 import java.io.File
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.text.appendLine

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/planner/ModuleClassPlannerAndroid.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/planner/ModuleClassPlannerAndroid.kt
@@ -2,7 +2,7 @@ package io.github.cdsap.projectgenerator.generator.planner
 
 import io.github.cdsap.projectgenerator.model.*
 import io.github.cdsap.projectgenerator.NameMappings
-import io.github.cdsap.projectgenerator.writer.ModuleClassPlanner
+import io.github.cdsap.projectgenerator.generator.ModuleClassPlanner
 
 /**
  * Plans what classes each module should have and their dependencies

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/planner/ModuleClassPlannerAndroidLegacy.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/planner/ModuleClassPlannerAndroidLegacy.kt
@@ -2,7 +2,7 @@ package io.github.cdsap.projectgenerator.generator.planner
 
 import io.github.cdsap.projectgenerator.model.*
 import io.github.cdsap.projectgenerator.NameMappings
-import io.github.cdsap.projectgenerator.writer.ModuleClassPlanner
+import io.github.cdsap.projectgenerator.generator.ModuleClassPlanner
 
 /**
  * Plans what classes each module should have and their dependencies

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/planner/ModuleClassPlannerJvm.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/planner/ModuleClassPlannerJvm.kt
@@ -1,6 +1,6 @@
 package io.github.cdsap.projectgenerator.generator.planner
 
-import io.github.cdsap.projectgenerator.writer.ModuleClassPlanner
+import io.github.cdsap.projectgenerator.generator.ModuleClassPlanner
 import io.github.cdsap.projectgenerator.model.*
 import io.github.cdsap.projectgenerator.NameMappings
 

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/resources/ResourceGenerator.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/resources/ResourceGenerator.kt
@@ -7,7 +7,7 @@ import io.github.cdsap.projectgenerator.generator.android.ClassTheme
 import io.github.cdsap.projectgenerator.generator.android.FragmentLayout
 import io.github.cdsap.projectgenerator.generator.android.Manifest
 import io.github.cdsap.projectgenerator.generator.android.ValuesStrings
-import io.github.cdsap.projectgenerator.writer.ResourceGeneratorA
+import io.github.cdsap.projectgenerator.generator.ResourceGeneratorA
 import io.github.cdsap.projectgenerator.NameMappings
 import io.github.cdsap.projectgenerator.generator.classes.GenerateDictionaryAndroid
 import io.github.cdsap.projectgenerator.model.DependencyInjection

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/test/TestGeneratorAndroid.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/test/TestGeneratorAndroid.kt
@@ -2,7 +2,7 @@ package io.github.cdsap.projectgenerator.generator.test
 
 import io.github.cdsap.projectgenerator.generator.GeneratedModuleLayout
 import io.github.cdsap.projectgenerator.generator.classes.GenerateDictionaryAndroid
-import io.github.cdsap.projectgenerator.writer.TestGenerator
+import io.github.cdsap.projectgenerator.generator.TestGenerator
 import io.github.cdsap.projectgenerator.model.ClassDefinitionAndroid
 import io.github.cdsap.projectgenerator.model.ClassDependencyAndroid
 import io.github.cdsap.projectgenerator.model.ClassTypeAndroid

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/test/TestGeneratorAndroidLegacy.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/test/TestGeneratorAndroidLegacy.kt
@@ -2,7 +2,7 @@ package io.github.cdsap.projectgenerator.generator.test
 
 import io.github.cdsap.projectgenerator.generator.android.AndroidSourceSetLayout
 import io.github.cdsap.projectgenerator.generator.classes.GenerateDictionaryAndroid
-import io.github.cdsap.projectgenerator.writer.TestGenerator
+import io.github.cdsap.projectgenerator.generator.TestGenerator
 import io.github.cdsap.projectgenerator.model.ClassDefinitionAndroid
 import io.github.cdsap.projectgenerator.model.ClassDependencyAndroid
 import io.github.cdsap.projectgenerator.model.ClassTypeAndroid

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/test/TestGeneratorJvm.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/test/TestGeneratorJvm.kt
@@ -1,6 +1,6 @@
 package io.github.cdsap.projectgenerator.generator.test
 
-import io.github.cdsap.projectgenerator.writer.TestGenerator
+import io.github.cdsap.projectgenerator.generator.TestGenerator
 import io.github.cdsap.projectgenerator.generator.classes.GenerateDictionaryJvm
 import io.github.cdsap.projectgenerator.model.ClassDefinitionJvm
 import io.github.cdsap.projectgenerator.model.ClassTypeJvm

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/ModulesWriter.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/ModulesWriter.kt
@@ -1,6 +1,11 @@
 package io.github.cdsap.projectgenerator.writer
 
+import io.github.cdsap.projectgenerator.generator.BuildFilesGenerator
+import io.github.cdsap.projectgenerator.generator.ClassGenerator
 import io.github.cdsap.projectgenerator.generator.GeneratedModuleLayout
+import io.github.cdsap.projectgenerator.generator.ModuleClassPlanner
+import io.github.cdsap.projectgenerator.generator.ResourceGeneratorA
+import io.github.cdsap.projectgenerator.generator.TestGenerator
 import io.github.cdsap.projectgenerator.model.LanguageAttributes
 import io.github.cdsap.projectgenerator.model.ProjectGraph
 import io.github.cdsap.projectgenerator.model.TypeOfStringResources
@@ -75,41 +80,4 @@ abstract class ModulesWrite<MODULE_DEF, DICT>(
             layout.testKotlinPackageDir().mkdirs()
         }
     }
-}
-
-interface ModuleClassPlanner<MODULE_DEF> {
-    fun planModuleClasses(node: ProjectGraph): MODULE_DEF
-}
-
-interface ClassGenerator<MODULE_DEF, DICT> {
-    fun generate(
-        moduleDefinition: MODULE_DEF,
-        projectName: String,
-        a: MutableMap<String, CopyOnWriteArrayList<DICT>>
-    )
-
-    fun obtainClassesGenerated(
-        moduleDefinition: MODULE_DEF,
-        classesDictionary: MutableMap<String, CopyOnWriteArrayList<DICT>>
-    ): MutableMap<String, CopyOnWriteArrayList<DICT>>
-}
-
-interface TestGenerator<MODULE_DEF, DICT> {
-    fun generate(
-        moduleDefinition: MODULE_DEF,
-        projectName: String,
-        classesDictionary: MutableMap<String, CopyOnWriteArrayList<DICT>>
-    )
-}
-
-interface BuildFilesGenerator {
-    fun generateBuildFiles(node: ProjectGraph, lang: LanguageAttributes, generateUnitTests: Boolean)
-}
-
-interface ResourceGeneratorA<DICT> {
-    fun generate(
-        node: ProjectGraph, lang: LanguageAttributes,
-        typeOfStringResources: TypeOfStringResources,
-        classesDictionary: MutableMap<String, CopyOnWriteArrayList<DICT>>
-    )
 }

--- a/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/generator/ModuleGenerationPortsTest.kt
+++ b/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/generator/ModuleGenerationPortsTest.kt
@@ -1,0 +1,23 @@
+package io.github.cdsap.projectgenerator.generator
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ModuleGenerationPortsTest {
+
+    @Test
+    fun `module generation ports live in the generator package`() {
+        val expectedPackage = "io.github.cdsap.projectgenerator.generator"
+        val ports = listOf(
+            ModuleClassPlanner::class,
+            ClassGenerator::class,
+            TestGenerator::class,
+            BuildFilesGenerator::class,
+            ResourceGeneratorA::class
+        )
+
+        ports.forEach { port ->
+            assertEquals(expectedPackage, port.java.packageName, "${port.simpleName} package")
+        }
+    }
+}

--- a/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/writer/ModulesWriterTest.kt
+++ b/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/writer/ModulesWriterTest.kt
@@ -1,6 +1,10 @@
 package io.github.cdsap.projectgenerator.writer
 
 import io.github.cdsap.projectgenerator.NameMappings
+import io.github.cdsap.projectgenerator.generator.BuildFilesGenerator
+import io.github.cdsap.projectgenerator.generator.ClassGenerator
+import io.github.cdsap.projectgenerator.generator.ModuleClassPlanner
+import io.github.cdsap.projectgenerator.generator.TestGenerator
 import io.github.cdsap.projectgenerator.model.LanguageAttributes
 import io.github.cdsap.projectgenerator.model.ProjectGraph
 import io.github.cdsap.projectgenerator.model.TypeProject


### PR DESCRIPTION
## Summary

### Problem

project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/ModulesWriter.kt defines the module-generation port interfaces at lines 87-122, while core generator implementations import them from the writer package, for example generator/planner/ModuleClassPlannerJvm.kt:3, generator/buildfiles/BuildFilesGeneratorJvm.kt:3, and generator/classes/ClassGeneratorJvm.kt:5.

### Why this matters

This makes planning, class generation, test generation, resource generation, and build-file generation depend on the writer/orchestration package for their abstractions. That reverses the intended dependency direction and makes the writer package look like the owner of core generation contracts, which raises coupling and makes future generator tests or alternate orchestration harder to reason about.

### Proposed change

Move ModuleClassPlanner, ClassGenerator, TestGenerator, BuildFilesGenerator, and ResourceGeneratorA unchanged into a small core-facing file such as project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/ModuleGenerationPorts.kt or generator/ports/ModuleGenerationPorts.kt, then update imports in ModulesWriter and the existing implementations. Keep names and method signatures unchanged.

### Notes

DDD and clean architecture lens: the writer is an adapter/orchestrator that should depend on generation contracts, not own the contracts that planners and generators implement. This is a small package-boundary cleanup with no domain model or output-format change.

Fixes #439

## Changes

- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/ModuleGenerationPorts.kt`
- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/buildfiles/BuildFilesGeneratorAndroid.kt`
- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/buildfiles/BuildFilesGeneratorJvm.kt`
- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/classes/ClassGeneratorAndroid.kt`
- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/classes/ClassGeneratorAndroidLegacy.kt`
- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/classes/ClassGeneratorJvm.kt`
- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/planner/ModuleClassPlannerAndroid.kt`
- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/planner/ModuleClassPlannerAndroidLegacy.kt`
- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/planner/ModuleClassPlannerJvm.kt`
- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/resources/ResourceGenerator.kt`
- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/test/TestGeneratorAndroid.kt`
- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/test/TestGeneratorAndroidLegacy.kt`
- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/test/TestGeneratorJvm.kt`
- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/ModulesWriter.kt`
- `project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/generator/ModuleGenerationPortsTest.kt`
- `project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/writer/ModulesWriterTest.kt`

## Verification

- `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`
