### PR TITLE
fix: drop android.newdsl=false for agp 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
           - 'io.github.cdsap.projectgenerator.ProjectGeneratorE2EJdk21Test'
           - 'io.github.cdsap.projectgenerator.RoomDiVariantsAssembleE2EValidationTest'
           - 'io.github.cdsap.projectgenerator.AndroidKotlinMultiplatformLibraryE2EValidationTest'
+          - 'io.github.cdsap.projectgenerator.Agp9NewDslDiVariantsE2EValidationTest'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: unit-tests

--- a/.github/workflows/update-gradle-versions.yml
+++ b/.github/workflows/update-gradle-versions.yml
@@ -64,6 +64,7 @@ jobs:
           - 'io.github.cdsap.projectgenerator.RoomDiVariantsAssembleE2EValidationTest'
           - 'io.github.cdsap.projectgenerator.AndroidKotlinMultiplatformLibraryE2EValidationTest'
           - 'io.github.cdsap.projectgenerator.SupportedGradleVersionsE2ETest'
+          - 'io.github.cdsap.projectgenerator.Agp9NewDslDiVariantsE2EValidationTest'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/rootproject/GradleProperties.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/rootproject/GradleProperties.kt
@@ -1,7 +1,5 @@
 package io.github.cdsap.projectgenerator.generator.rootproject
 
-import io.github.cdsap.projectgenerator.generator.extension.isAgp9
-import io.github.cdsap.projectgenerator.model.DependencyInjection
 import io.github.cdsap.projectgenerator.model.Gradle
 import io.github.cdsap.projectgenerator.model.Processor
 import io.github.cdsap.projectgenerator.model.Versions
@@ -16,10 +14,6 @@ class GradleProperties {
             if (versions.kotlin.kotlinProcessor.processor == Processor.KSP) {
                 // Disable K2 for KSP 2.0
                 add("ksp.useKSP2=false")
-            }
-            if (versions.di == DependencyInjection.HILT && versions.android.agp.isAgp9()) {
-                // Hilt is not compatible with AGP9 new DSL
-                add("android.newDsl=false")
             }
             if (isGradle97(gradle)) {
                 // Isolated Projects + KSP IP-compatible task wiring (Gradle 9.7 only)

--- a/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/Agp9NewDslDiVariantsE2EValidationTest.kt
+++ b/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/Agp9NewDslDiVariantsE2EValidationTest.kt
@@ -1,0 +1,81 @@
+package io.github.cdsap.projectgenerator
+
+import io.github.cdsap.projectgenerator.DefaultTestVersions.Companion.LATEST_GRADLE
+import io.github.cdsap.projectgenerator.model.ClassesPerModule
+import io.github.cdsap.projectgenerator.model.ClassesPerModuleType
+import io.github.cdsap.projectgenerator.model.DependencyInjection
+import io.github.cdsap.projectgenerator.model.Language
+import io.github.cdsap.projectgenerator.model.Project
+import io.github.cdsap.projectgenerator.model.Shape
+import io.github.cdsap.projectgenerator.model.TypeOfStringResources
+import io.github.cdsap.projectgenerator.model.TypeProjectRequested
+import io.github.cdsap.projectgenerator.model.Versions
+import io.github.cdsap.projectgenerator.writer.GradleWrapper
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.io.File
+import java.nio.file.Path
+
+class Agp9NewDslDiVariantsE2EValidationTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    @ParameterizedTest
+    @EnumSource(DependencyInjection::class)
+    fun `agp9 android project without newDsl opt-out compiles and reuses configuration cache`(
+        di: DependencyInjection
+    ) {
+        val projectName = "agp9_newdsl_${di.name.lowercase()}"
+        ProjectGenerator(
+            modules = 6,
+            shape = Shape.FLAT,
+            language = Language.KTS,
+            typeOfProjectRequested = TypeProjectRequested.ANDROID,
+            classesPerModule = ClassesPerModule(ClassesPerModuleType.FIXED, 10),
+            versions = Versions(
+                project = Project(jdk = "21"),
+                di = di
+            ),
+            typeOfStringResources = TypeOfStringResources.NORMAL,
+            layers = 2,
+            generateUnitTest = false,
+            gradle = GradleWrapper(LATEST_GRADLE),
+            projectRootPath = "${tempDir.toFile().path}/$projectName/project_kts",
+            projectName = projectName
+        ).write()
+
+        val projectDir = File("$tempDir/$projectName/project_kts")
+        AndroidSdkTestSupport.writeLocalProperties(projectDir)
+
+        val gradleProperties = File(projectDir, "gradle.properties").readText()
+        assertFalse(
+            gradleProperties.contains("android.newDsl"),
+            "Generated gradle.properties must not opt out of AGP 9 new DSL for $di"
+        )
+
+        val first = runWithConfigurationCache(projectDir)
+        assertTrue(first.output.contains("BUILD SUCCESSFUL"))
+        assertTrue(
+            first.output.contains("Configuration cache entry stored") ||
+                first.output.contains("Calculating task graph"),
+            "Expected configuration cache to store an entry for $di:\n${first.output}"
+        )
+
+        val second = runWithConfigurationCache(projectDir)
+        assertTrue(second.output.contains("BUILD SUCCESSFUL"))
+        assertTrue(
+            second.output.contains("Reusing configuration cache") ||
+                second.output.contains("Configuration cache entry reused"),
+            "Expected configuration cache reuse for $di:\n${second.output}"
+        )
+    }
+
+    private fun runWithConfigurationCache(projectDir: File) = GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("--configuration-cache", "assembleDebug")
+        .build()
+}

--- a/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/Agp9NewDslDiVariantsE2EValidationTest.kt
+++ b/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/Agp9NewDslDiVariantsE2EValidationTest.kt
@@ -14,6 +14,7 @@ import io.github.cdsap.projectgenerator.writer.GradleWrapper
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeFalse
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -29,6 +30,10 @@ class Agp9NewDslDiVariantsE2EValidationTest {
     fun `agp9 android project without newDsl opt-out compiles and reuses configuration cache`(
         di: DependencyInjection
     ) {
+        assumeFalse(
+            di == DependencyInjection.METRO && Runtime.version().feature() < 21,
+            "Metro Gradle plugin requires JVM 21 to run"
+        )
         val projectName = "agp9_newdsl_${di.name.lowercase()}"
         ProjectGenerator(
             modules = 6,

--- a/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/generator/files/GradlePropertiesTest.kt
+++ b/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/generator/files/GradlePropertiesTest.kt
@@ -65,7 +65,7 @@ class GradlePropertiesTest {
     }
 
     @Test
-    fun `includes android newDsl override for hilt on agp9`() {
+    fun `does not include android newDsl override for hilt on agp9`() {
         val versions = Versions(
             android = Android(agp = "9.1.0"),
             di = DependencyInjection.HILT
@@ -73,19 +73,24 @@ class GradlePropertiesTest {
 
         val gradleProperties = GradleProperties().get(versions, Gradle("9.6.1"))
 
-        Assertions.assertTrue(gradleProperties.contains("android.newDsl=false"))
+        Assertions.assertFalse(gradleProperties.contains("android.newDsl"))
     }
 
     @Test
-    fun `does not include android newDsl override for hilt on agp8`() {
-        val versions = Versions(
-            android = Android(agp = "8.10.0"),
-            di = DependencyInjection.HILT
-        )
+    fun `does not include android newDsl override for any di on agp9`() {
+        DependencyInjection.entries.forEach { di ->
+            val versions = Versions(
+                android = Android(agp = "9.4.0"),
+                di = di
+            )
 
-        val gradleProperties = GradleProperties().get(versions, Gradle("9.6.1"))
+            val gradleProperties = GradleProperties().get(versions, Gradle("9.6.1"))
 
-        Assertions.assertFalse(gradleProperties.contains("android.newDsl=false"))
+            Assertions.assertFalse(
+                gradleProperties.contains("android.newDsl"),
+                "Unexpected android.newDsl property for $di"
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Evaluate if we can drop `android.newDsl=false` for projects generated with AGP9+.
We need to generate projects without the property and test that the project compiles, and hits the configuration cache for the different variants of DI

Fixes #441

## Changes

- `.github/workflows/build.yml`
- `.github/workflows/update-gradle-versions.yml`
- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/generator/rootproject/GradleProperties.kt`
- `project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/Agp9NewDslDiVariantsE2EValidationTest.kt`
- `project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/generator/files/GradlePropertiesTest.kt`

## Verification

- `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`
