### PR TITLE
fix: refactor graphwriter to separate dot rendering from file i/o

### DIFF
--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/GraphWriter.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/GraphWriter.kt
@@ -10,18 +10,25 @@ class GraphWriter(private val nodes: List<ProjectGraph>, val path: String) {
         println("Creating graph file")
         val file = File("$path/graph.dot")
         file.createNewFile()
+        file.writeText(render(nodes))
+    }
 
-        val content = StringBuilder()
-        content.appendLine("digraph G {")
+    companion object {
+        fun render(nodes: List<ProjectGraph>): String {
+            val content = StringBuilder()
+            content.appendLine("digraph G {")
 
-        for (nodeGraph in nodes) {
-            val node = "${NameMappings.layerName(nodeGraph.layer)}:${NameMappings.moduleName(nodeGraph.id)}"
-            for (dep in nodeGraph.nodes) {
-                content.appendLine("\"$node\" -> \"${NameMappings.layerName(dep.layer)}:${NameMappings.moduleName(dep.id)}\";")
+            for (nodeGraph in nodes) {
+                val node = "${NameMappings.layerName(nodeGraph.layer)}:${NameMappings.moduleName(nodeGraph.id)}"
+                for (dep in nodeGraph.nodes) {
+                    content.appendLine(
+                        "\"$node\" -> \"${NameMappings.layerName(dep.layer)}:${NameMappings.moduleName(dep.id)}\";"
+                    )
+                }
             }
-        }
 
-        content.appendLine("}")
-        file.writeText(content.toString())
+            content.appendLine("}")
+            return content.toString()
+        }
     }
 }

--- a/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/writer/GraphWriterTest.kt
+++ b/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/writer/GraphWriterTest.kt
@@ -1,0 +1,67 @@
+package io.github.cdsap.projectgenerator.writer
+
+import io.github.cdsap.projectgenerator.NameMappings
+import io.github.cdsap.projectgenerator.model.ProjectGraph
+import io.github.cdsap.projectgenerator.model.TypeProject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+
+class GraphWriterTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `render builds digraph edges with layer module labels from NameMappings`() {
+        val previousLayerNames = NameMappings.layerNames
+        val previousModuleNames = NameMappings.moduleNames
+        NameMappings.layerNames = mapOf(1 to "layer_1", 2 to "app")
+        NameMappings.moduleNames = mapOf("module_1_1" to "sample-lib", "module_2_1" to "app")
+        try {
+            val lib = ProjectGraph("module_1_1", 1, emptyList(), TypeProject.LIB, 1)
+            val app = ProjectGraph("module_2_1", 2, listOf(lib), TypeProject.ANDROID_APP, 1)
+
+            val dot = GraphWriter.render(listOf(lib, app))
+
+            assertEquals(
+                """
+                digraph G {
+                "app:app" -> "layer_1:sample-lib";
+                }
+
+                """.trimIndent(),
+                dot
+            )
+        } finally {
+            NameMappings.layerNames = previousLayerNames
+            NameMappings.moduleNames = previousModuleNames
+        }
+    }
+
+    @Test
+    fun `write writes render output to graph dot`() {
+        val previousLayerNames = NameMappings.layerNames
+        val previousModuleNames = NameMappings.moduleNames
+        NameMappings.layerNames = mapOf(1 to "layer_1", 2 to "app")
+        NameMappings.moduleNames = mapOf("module_1_1" to "sample-lib", "module_2_1" to "app")
+        try {
+            val lib = ProjectGraph("module_1_1", 1, emptyList(), TypeProject.LIB, 1)
+            val app = ProjectGraph("module_2_1", 2, listOf(lib), TypeProject.ANDROID_APP, 1)
+            val nodes = listOf(lib, app)
+            val outDir = tempDir.resolve("out").toFile().also { it.mkdirs() }
+
+            GraphWriter(nodes, outDir.path).write()
+
+            val graphFile = File(outDir, "graph.dot")
+            assertTrue(graphFile.exists())
+            assertEquals(GraphWriter.render(nodes), graphFile.readText())
+        } finally {
+            NameMappings.layerNames = previousLayerNames
+            NameMappings.moduleNames = previousModuleNames
+        }
+    }
+}


### PR DESCRIPTION
## Summary

### Problem

`project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/GraphWriter.kt` mixes pure dependency-graph → DOT string construction with filesystem side effects (`File.createNewFile()`, `writeText`, `println`). There is no unit test of the DOT content—only `ProjectGeneratorTest` asserts that `graph.dot` exists. Elsewhere the repo already separates content builders from writers (`SettingsGradle.get()`, `AndroidToml.toml()`, CLI `GenerateVersionsYaml.render()`).

### Why this matters

Graph edge labels and include paths depend on `NameMappings`; regressions in DOT output are hard to catch without spinning up full project generation. Coupling rendering to disk also blocks testing naming/edge cases in isolation and blurs the writer adapter vs. domain presentation boundary.

### Proposed change

Extract a pure `render(nodes: List<ProjectGraph>): String` (or equivalent) on `GraphWriter` that builds the digraph body; keep `write()` as a thin adapter that creates `$path/graph.dot` and writes that string. Add a focused unit test asserting edge lines for a small fixed graph (with controlled `NameMappings` like `ProjectWriterTest` already does). Do not change DOT format, file path, or call sites in `ProjectGenerator`.

### Notes

Clean architecture: treat DOT serialization as a pure presentation of the `ProjectGraph` domain model; leave `java.io.File` in the infrastructure adapter. This is a single-boundary, incremental step—not a rewrite of the writer layer.

Fixes #443

## Changes

- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/GraphWriter.kt`
- `project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/writer/GraphWriterTest.kt`

## Verification

- `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`
