### PR TITLE
fix: refactor gradle resolution into versionsresolver

### DIFF
--- a/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt
@@ -84,7 +84,7 @@ data class GenerateProjectRequest(
                 typeOfStringResources = typeOfStringResources,
                 layers = layers,
                 generateUnitTest = generateUnitTest,
-                gradle = resolveGradle(cliGradle, versionsFile),
+                gradle = VersionsResolver.resolveGradle(cliGradle, versionsFile),
                 projectRootPath = resolveProjectRootPath(outputDir, language, resolvedProjectName),
                 develocity = resolveDevelocityEnabled(develocityFlag, versionsOverrides.develocityUrl),
                 projectName = resolvedProjectName
@@ -134,10 +134,4 @@ internal fun resolveProjectRootPath(outputDir: String?, language: Language, proj
             Language.BOTH -> "projects_generated/$projectName"
         }
     }
-}
-
-internal fun resolveGradle(cliGradle: String?, versionsFile: VersionsFile?): Gradle {
-    return cliGradle?.let(Gradle::fromValue)
-        ?: versionsFile?.gradle
-        ?: Gradle.latest()
 }

--- a/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolver.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolver.kt
@@ -1,6 +1,7 @@
 package io.github.cdsap.projectgenerator.cli
 
 import io.github.cdsap.projectgenerator.model.DependencyInjection
+import io.github.cdsap.projectgenerator.model.Gradle
 import io.github.cdsap.projectgenerator.model.Versions
 import io.github.cdsap.projectgenerator.model.VersionsFile
 
@@ -36,5 +37,11 @@ object VersionsResolver {
     ): Versions {
         val base = fileVersions?.resolve() ?: Versions()
         return overrides.applyTo(base)
+    }
+
+    fun resolveGradle(cliGradle: String?, fileVersions: VersionsFile?): Gradle {
+        return cliGradle?.let(Gradle::fromValue)
+            ?: fileVersions?.gradle
+            ?: Gradle.latest()
     }
 }

--- a/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
+++ b/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
@@ -10,7 +10,6 @@ import io.github.cdsap.projectgenerator.model.Language
 import io.github.cdsap.projectgenerator.model.Shape
 import io.github.cdsap.projectgenerator.model.TypeOfStringResources
 import io.github.cdsap.projectgenerator.model.TypeProjectRequested
-import io.github.cdsap.projectgenerator.model.VersionsFile
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -133,28 +132,6 @@ class GenerateProjectsCliTest {
 
         assertTrue(error.message?.contains("Unknown Gradle version: 9.9.9") == true)
         assertTrue(error.message?.contains(Gradle.supportedDisplayValues()) == true)
-    }
-
-    @Test
-    fun `gradle from versions file is used when flag is absent`() {
-        val configured = Gradle.supported()[1]
-        val resolved = resolveGradle(null, VersionsFile(gradle = configured))
-
-        assertEquals(configured, resolved)
-    }
-
-    @Test
-    fun `gradle flag overrides versions file`() {
-        val resolved = resolveGradle(Gradle.latest().cliValue, VersionsFile(gradle = Gradle.oldest()))
-
-        assertEquals(Gradle.latest(), resolved)
-    }
-
-    @Test
-    fun `latest gradle is used when neither flag nor versions file provide one`() {
-        val resolved = resolveGradle(null, null)
-
-        assertEquals(Gradle.latest(), resolved)
     }
 
     @Test

--- a/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolverTest.kt
+++ b/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolverTest.kt
@@ -2,6 +2,7 @@ package io.github.cdsap.projectgenerator.cli
 
 import io.github.cdsap.projectgenerator.model.Android
 import io.github.cdsap.projectgenerator.model.DependencyInjection
+import io.github.cdsap.projectgenerator.model.Gradle
 import io.github.cdsap.projectgenerator.model.Project
 import io.github.cdsap.projectgenerator.model.Versions
 import io.github.cdsap.projectgenerator.model.VersionsFile
@@ -85,5 +86,30 @@ class VersionsResolverTest {
         assertTrue(resolved.android.kotlinMultiplatformLibrary)
         assertEquals("", resolved.project.develocityUrl)
         assertEquals(DependencyInjection.METRO, resolved.di)
+    }
+
+    @Test
+    fun `gradle from versions file is used when flag is absent`() {
+        val configured = Gradle.supported()[1]
+        val resolved = VersionsResolver.resolveGradle(null, VersionsFile(gradle = configured))
+
+        assertEquals(configured, resolved)
+    }
+
+    @Test
+    fun `gradle flag overrides versions file`() {
+        val resolved = VersionsResolver.resolveGradle(
+            Gradle.latest().cliValue,
+            VersionsFile(gradle = Gradle.oldest())
+        )
+
+        assertEquals(Gradle.latest(), resolved)
+    }
+
+    @Test
+    fun `latest gradle is used when neither flag nor versions file provide one`() {
+        val resolved = VersionsResolver.resolveGradle(null, null)
+
+        assertEquals(Gradle.latest(), resolved)
     }
 }


### PR DESCRIPTION
## Summary

### Problem

Gradle wrapper version precedence (CLI `--gradle` > `versions.yaml` > `Gradle.latest()`) lives in `resolveGradle()` inside `cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt`, while dependency/plugin versions are resolved in `cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolver.kt`. Both consume the same `VersionsFile` and CLI inputs, but configuration resolution is split across two application-layer types, with Gradle precedence tests in `cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt` instead of `VersionsResolverTest.kt`.

### Why this matters

The split boundary makes precedence rules easy to update inconsistently and scatters related tests. `GenerateProjectRequest.resolve()` should orchestrate inputs and outputs, not own every merge policy for values that already come from the same versions file.

### Proposed change

Move `resolveGradle(cliGradle, versionsFile)` into `VersionsResolver` (e.g. `fun resolveGradle(cliGradle: String?, fileVersions: VersionsFile?): Gradle`), delete the standalone helper from `GenerateProjectRequest.kt`, and call `VersionsResolver.resolveGradle(...)` from `GenerateProjectRequest.resolve()`. Move the three Gradle precedence tests from `GenerateProjectsCliTest.kt` to `VersionsResolverTest.kt`. No behavior or public CLI surface changes.

### Notes

DDD/clean-architecture lens: treat `VersionsResolver` as the application service for configuration merging (infrastructure YAML + CLI adapter inputs → domain `Versions`/`Gradle`), and keep `GenerateProjectRequest` as a thin use-case assembler. This is a behavior-preserving extraction aligned with the existing `VersionsOverrides.applyTo` pattern.

Fixes #446

## Changes

- `cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt`
- `cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolver.kt`
- `cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt`
- `cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/VersionsResolverTest.kt`

## Verification

- `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`
