### PR TITLE
fix: refactor project output layout into shared projectlayout domain typ

### DIFF
--- a/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt
@@ -5,6 +5,7 @@ import io.github.cdsap.projectgenerator.ProjectGenerator
 import io.github.cdsap.projectgenerator.model.ClassesPerModule
 import io.github.cdsap.projectgenerator.model.Gradle
 import io.github.cdsap.projectgenerator.model.Language
+import io.github.cdsap.projectgenerator.model.ProjectLayout
 import io.github.cdsap.projectgenerator.model.Shape
 import io.github.cdsap.projectgenerator.model.TypeOfStringResources
 import io.github.cdsap.projectgenerator.model.TypeProjectRequested
@@ -85,7 +86,7 @@ data class GenerateProjectRequest(
                 layers = layers,
                 generateUnitTest = generateUnitTest,
                 gradle = VersionsResolver.resolveGradle(cliGradle, versionsFile),
-                projectRootPath = resolveProjectRootPath(outputDir, language, resolvedProjectName),
+                projectRootPath = ProjectLayout.defaultRootPath(outputDir, language, resolvedProjectName),
                 develocity = resolveDevelocityEnabled(develocityFlag, versionsOverrides.develocityUrl),
                 projectName = resolvedProjectName
             )
@@ -122,16 +123,4 @@ internal fun resolveProjectName(
 
 internal fun resolveDevelocityEnabled(develocity: Boolean, develocityUrl: String?): Boolean {
     return develocity || develocityUrl != null
-}
-
-internal fun resolveProjectRootPath(outputDir: String?, language: Language, projectName: String): String {
-    return if (outputDir != null) {
-        outputDir
-    } else {
-        when (language) {
-            Language.KTS -> "projects_generated/$projectName/project_kts"
-            Language.GROOVY -> "projects_generated/$projectName/project_groovy"
-            Language.BOTH -> "projects_generated/$projectName"
-        }
-    }
 }

--- a/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
+++ b/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
@@ -7,6 +7,7 @@ import io.github.cdsap.projectgenerator.model.ClassesPerModuleType
 import io.github.cdsap.projectgenerator.model.DependencyInjection
 import io.github.cdsap.projectgenerator.model.Gradle
 import io.github.cdsap.projectgenerator.model.Language
+import io.github.cdsap.projectgenerator.model.ProjectLayout
 import io.github.cdsap.projectgenerator.model.Shape
 import io.github.cdsap.projectgenerator.model.TypeOfStringResources
 import io.github.cdsap.projectgenerator.model.TypeProjectRequested
@@ -136,21 +137,21 @@ class GenerateProjectsCliTest {
 
     @Test
     fun `default output path for kts nests project name and project_kts`() {
-        val resolved = resolveProjectRootPath(null, Language.KTS, "sample")
+        val resolved = ProjectLayout.defaultRootPath(null, Language.KTS, "sample")
 
         assertEquals("projects_generated/sample/project_kts", resolved)
     }
 
     @Test
     fun `output dir is used directly for single language projects`() {
-        val resolved = resolveProjectRootPath(".", Language.KTS, "sample")
+        val resolved = ProjectLayout.defaultRootPath(".", Language.KTS, "sample")
 
         assertEquals(".", resolved)
     }
 
     @Test
     fun `default output path for both languages nests project name only`() {
-        val resolved = resolveProjectRootPath(null, Language.BOTH, "sample")
+        val resolved = ProjectLayout.defaultRootPath(null, Language.BOTH, "sample")
 
         assertEquals("projects_generated/sample", resolved)
     }

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/ProjectGenerator.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/ProjectGenerator.kt
@@ -46,7 +46,7 @@ class ProjectGenerator(
             )
         )
 
-        val projectLanguageAttributes = getProjectLanguageAttributes()
+        val projectLanguageAttributes = ProjectLayout.languageAttributes(projectRootPath, language)
         ProjectWriter(
             nodes,
             projectLanguageAttributes,
@@ -62,22 +62,5 @@ class ProjectGenerator(
             GraphWriter(nodes, attributes.projectName).write()
         }
         println("Project created in ${projectLanguageAttributes.first().projectName}")
-    }
-
-    private fun getProjectLanguageAttributes(): List<LanguageAttributes> {
-        return when (language) {
-            Language.KTS -> listOf(
-                LanguageAttributes("gradle.kts", projectRootPath)
-            )
-
-            Language.GROOVY -> listOf(
-                LanguageAttributes("gradle", projectRootPath)
-            )
-
-            Language.BOTH -> listOf(
-                LanguageAttributes("gradle", "$projectRootPath/project_groovy"),
-                LanguageAttributes("gradle.kts", "$projectRootPath/project_kts")
-            )
-        }
     }
 }

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/model/ProjectLayout.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/model/ProjectLayout.kt
@@ -1,0 +1,32 @@
+package io.github.cdsap.projectgenerator.model
+
+object ProjectLayout {
+    fun defaultRootPath(outputDir: String?, language: Language, projectName: String): String {
+        return if (outputDir != null) {
+            outputDir
+        } else {
+            when (language) {
+                Language.KTS -> "projects_generated/$projectName/project_kts"
+                Language.GROOVY -> "projects_generated/$projectName/project_groovy"
+                Language.BOTH -> "projects_generated/$projectName"
+            }
+        }
+    }
+
+    fun languageAttributes(rootPath: String, language: Language): List<LanguageAttributes> {
+        return when (language) {
+            Language.KTS -> listOf(
+                LanguageAttributes("gradle.kts", rootPath)
+            )
+
+            Language.GROOVY -> listOf(
+                LanguageAttributes("gradle", rootPath)
+            )
+
+            Language.BOTH -> listOf(
+                LanguageAttributes("gradle", "$rootPath/project_groovy"),
+                LanguageAttributes("gradle.kts", "$rootPath/project_kts")
+            )
+        }
+    }
+}

--- a/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/model/ProjectLayoutTest.kt
+++ b/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/model/ProjectLayoutTest.kt
@@ -1,0 +1,76 @@
+package io.github.cdsap.projectgenerator.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ProjectLayoutTest {
+
+    @Test
+    fun `default root path for kts nests project name and project_kts`() {
+        val resolved = ProjectLayout.defaultRootPath(null, Language.KTS, "sample")
+
+        assertEquals("projects_generated/sample/project_kts", resolved)
+    }
+
+    @Test
+    fun `default root path for groovy nests project name and project_groovy`() {
+        val resolved = ProjectLayout.defaultRootPath(null, Language.GROOVY, "sample")
+
+        assertEquals("projects_generated/sample/project_groovy", resolved)
+    }
+
+    @Test
+    fun `default root path for both languages nests project name only`() {
+        val resolved = ProjectLayout.defaultRootPath(null, Language.BOTH, "sample")
+
+        assertEquals("projects_generated/sample", resolved)
+    }
+
+    @Test
+    fun `output dir is used directly for kts`() {
+        val resolved = ProjectLayout.defaultRootPath(".", Language.KTS, "sample")
+
+        assertEquals(".", resolved)
+    }
+
+    @Test
+    fun `output dir is used directly for groovy`() {
+        val resolved = ProjectLayout.defaultRootPath("/tmp/out", Language.GROOVY, "sample")
+
+        assertEquals("/tmp/out", resolved)
+    }
+
+    @Test
+    fun `output dir is used directly for both languages`() {
+        val resolved = ProjectLayout.defaultRootPath("/tmp/out", Language.BOTH, "sample")
+
+        assertEquals("/tmp/out", resolved)
+    }
+
+    @Test
+    fun `language attributes for kts use root path directly`() {
+        val attributes = ProjectLayout.languageAttributes("/tmp/project", Language.KTS)
+
+        assertEquals(listOf(LanguageAttributes("gradle.kts", "/tmp/project")), attributes)
+    }
+
+    @Test
+    fun `language attributes for groovy use root path directly`() {
+        val attributes = ProjectLayout.languageAttributes("/tmp/project", Language.GROOVY)
+
+        assertEquals(listOf(LanguageAttributes("gradle", "/tmp/project")), attributes)
+    }
+
+    @Test
+    fun `language attributes for both languages use language subdirectories`() {
+        val attributes = ProjectLayout.languageAttributes("/tmp/project", Language.BOTH)
+
+        assertEquals(
+            listOf(
+                LanguageAttributes("gradle", "/tmp/project/project_groovy"),
+                LanguageAttributes("gradle.kts", "/tmp/project/project_kts")
+            ),
+            attributes
+        )
+    }
+}


### PR DESCRIPTION
## Summary

### Problem

Filesystem layout rules for Language (KTS, GROOVY, BOTH) are duplicated across `cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt` (`resolveProjectRootPath`) and `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/ProjectGenerator.kt` (`getProjectLanguageAttributes`). The CLI picks a root path and the generator expands it into `LanguageAttributes`, but both encode the same policy with no single source of truth.

### Why this matters

This is domain policy, not CLI or I/O detail. If one side changes (for example how `--output-dir` interacts with `Language.BOTH`) without the other, the CLI can report one location while files are written elsewhere. Tests are split across `GenerateProjectsCliTest` and `ProjectGeneratorTest`, so regressions are easy to miss.

### Proposed change

Add `ProjectLayout` in `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/model/` with two pure functions: `defaultRootPath(outputDir, language, projectName)` (replacing `resolveProjectRootPath`) and `languageAttributes(rootPath, language)` (replacing `getProjectLanguageAttributes`). Update `GenerateProjectRequest.resolve` and `ProjectGenerator.write()` to delegate to it. Add focused unit tests in `project-generator` for all language/output-dir combinations.

### Notes

In clean-architecture terms, output layout is a domain policy consumed by the CLI adapter and the generation use case. Centralizing it in `model/` keeps infrastructure (Clikt, `File` writers) separate from the rule of where each language variant lives on disk, and gives library callers the same layout contract the CLI uses.

Fixes #448

## Changes

- `cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt`
- `cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt`
- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/ProjectGenerator.kt`
- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/model/ProjectLayout.kt`
- `project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/model/ProjectLayoutTest.kt`

## Verification

- `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`
