### PR TITLE
fix: refactor android feature validation to isolate cli errors from requ

### DIFF
--- a/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt
@@ -1,6 +1,5 @@
 package io.github.cdsap.projectgenerator.cli
 
-import com.github.ajalt.clikt.core.UsageError
 import io.github.cdsap.projectgenerator.ProjectGenerator
 import io.github.cdsap.projectgenerator.model.ClassesPerModule
 import io.github.cdsap.projectgenerator.model.Gradle
@@ -94,16 +93,22 @@ data class GenerateProjectRequest(
     }
 }
 
+internal class GenerateProjectRequestValidationException(
+    message: String
+) : RuntimeException(message)
+
 internal fun validateAndroidOnlyFeatures(
     typeOfProjectRequested: TypeProjectRequested,
     roomDatabase: Boolean,
     kotlinMultiplatformLibrary: Boolean
 ) {
     if (typeOfProjectRequested != TypeProjectRequested.ANDROID && roomDatabase) {
-        throw UsageError("--room-database is only available when --type android.")
+        throw GenerateProjectRequestValidationException("--room-database is only available when --type android.")
     }
     if (typeOfProjectRequested != TypeProjectRequested.ANDROID && kotlinMultiplatformLibrary) {
-        throw UsageError("--android-kotlin-multiplatform-library is only available when --type android.")
+        throw GenerateProjectRequestValidationException(
+            "--android-kotlin-multiplatform-library is only available when --type android."
+        )
     }
 }
 

--- a/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt
@@ -1,6 +1,7 @@
 package io.github.cdsap.projectgenerator.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.options.*
@@ -55,30 +56,34 @@ class GenerateProjects : CliktCommand(name = "generate-project") {
     private val kotlinMultiplatformLibrary by option("--android-kotlin-multiplatform-library").flag(default = false)
 
     override fun run() {
-        GenerateProjectRequest.resolve(
-            modules = modules,
-            shape = Shape.valueOf(shape.uppercase()),
-            language = Language.valueOf(language.uppercase()),
-            typeOfProjectRequested = TypeProjectRequested.valueOf(type.uppercase()),
-            classesPerModule = ClassesPerModule(
-                ClassesPerModuleType.valueOf(classesModuleType.uppercase()),
-                classesModule
-            ),
-            typeOfStringResources = TypeOfStringResources.valueOf(typeOfStringResources.uppercase()),
-            layers = layers,
-            generateUnitTest = generateUnitTest,
-            cliGradle = gradle,
-            develocityFlag = develocity,
-            versionsFile = versionsFile?.let(VersionsParser::fromFile),
-            outputDir = outputDir,
-            projectName = projectName,
-            versionsOverrides = VersionsOverrides(
-                dependencyInjection = DependencyInjection.valueOf(di.uppercase()),
-                develocityUrl = develocityUrl,
-                roomDatabase = roomDatabase,
-                kotlinMultiplatformLibrary = kotlinMultiplatformLibrary
-            )
-        ).toProjectGenerator().write()
+        try {
+            GenerateProjectRequest.resolve(
+                modules = modules,
+                shape = Shape.valueOf(shape.uppercase()),
+                language = Language.valueOf(language.uppercase()),
+                typeOfProjectRequested = TypeProjectRequested.valueOf(type.uppercase()),
+                classesPerModule = ClassesPerModule(
+                    ClassesPerModuleType.valueOf(classesModuleType.uppercase()),
+                    classesModule
+                ),
+                typeOfStringResources = TypeOfStringResources.valueOf(typeOfStringResources.uppercase()),
+                layers = layers,
+                generateUnitTest = generateUnitTest,
+                cliGradle = gradle,
+                develocityFlag = develocity,
+                versionsFile = versionsFile?.let(VersionsParser::fromFile),
+                outputDir = outputDir,
+                projectName = projectName,
+                versionsOverrides = VersionsOverrides(
+                    dependencyInjection = DependencyInjection.valueOf(di.uppercase()),
+                    develocityUrl = develocityUrl,
+                    roomDatabase = roomDatabase,
+                    kotlinMultiplatformLibrary = kotlinMultiplatformLibrary
+                )
+            ).toProjectGenerator().write()
+        } catch (e: GenerateProjectRequestValidationException) {
+            throw UsageError(e.message ?: "Invalid generate-project request.")
+        }
     }
 }
 

--- a/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
+++ b/cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt
@@ -51,7 +51,7 @@ class GenerateProjectsCliTest {
 
     @Test
     fun `resolve rejects room database for jvm type`() {
-        val error = assertThrows<UsageError> {
+        val error = assertThrows<GenerateProjectRequestValidationException> {
             GenerateProjectRequest.resolve(
                 modules = 6,
                 shape = Shape.RECTANGLE,
@@ -79,7 +79,7 @@ class GenerateProjectsCliTest {
 
     @Test
     fun `resolve rejects android kotlin multiplatform library for jvm type`() {
-        val error = assertThrows<UsageError> {
+        val error = assertThrows<GenerateProjectRequestValidationException> {
             GenerateProjectRequest.resolve(
                 modules = 6,
                 shape = Shape.RECTANGLE,


### PR DESCRIPTION
## Summary

### Problem

cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt:3 imports Clikt UsageError, and validateAndroidOnlyFeatures at lines 96-106 throws CLI-framework exceptions from the request-resolution code used by GenerateProjectRequest.resolve at lines 47-92. Main.kt lines 57-81 is the actual Clikt command boundary, while GenerateProjectRequest also resolves project name, Gradle version, output path, Develocity enablement, and versions overrides. Tests in cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt:52-108 assert UsageError directly from GenerateProjectRequest.resolve, so the framework coupling is now part of lower-level resolver behavior.

### Why this matters

The request resolver is close to an application/service boundary: it turns parsed inputs into a ProjectGenerator request. Having it construct Clikt exceptions makes that behavior harder to reuse from another adapter, such as the backend or tests that want pure request validation, and forces non-CLI logic to depend on CLI presentation concerns.

### Proposed change

Introduce a tiny CLI-domain validation result for Android-only feature compatibility, for example an internal ProjectFeatureCompatibility or GenerateProjectRequestValidation helper that returns a violation message or throws a small project-local exception. Keep UsageError creation in GenerateProjects.run, or in a thin Clikt adapter around GenerateProjectRequest.resolve. Preserve the existing messages and behavior for CLI users. Update GenerateProjectsCliTest so command parsing still expects UsageError, while direct resolver/validation tests assert the project-local validation result or exception instead of Clikt.

### Notes

DDD/clean architecture lens: keep the application request assembly and feature compatibility policy independent from the Clikt delivery mechanism. This is a small adapter-boundary cleanup, not a redesign.

Fixes #451

## Changes

- `cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectRequest.kt`
- `cli/src/main/kotlin/io/github/cdsap/projectgenerator/cli/Main.kt`
- `cli/src/test/kotlin/io/github/cdsap/projectgenerator/cli/GenerateProjectsCliTest.kt`

## Verification

- `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`
