### PR TITLE
fix: refactor graphwriter to consume explicit projectnamemaps

### DIFF
--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/ProjectGenerator.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/ProjectGenerator.kt
@@ -37,14 +37,13 @@ class ProjectGenerator(
             classesPerModule
         ).generate()
 
-        NameMappings.configure(
-            ProjectNameMappingFactory.create(
-                layers = layers,
-                nodes = nodes,
-                layerNames = layerNames,
-                moduleNameParts = moduleNameParts
-            )
+        val nameMaps = ProjectNameMappingFactory.create(
+            layers = layers,
+            nodes = nodes,
+            layerNames = layerNames,
+            moduleNameParts = moduleNameParts
         )
+        NameMappings.configure(nameMaps)
 
         val projectLanguageAttributes = ProjectLayout.languageAttributes(projectRootPath, language)
         ProjectWriter(
@@ -59,7 +58,7 @@ class ProjectGenerator(
             projectName
         ).write()
         projectLanguageAttributes.forEach { attributes ->
-            GraphWriter(nodes, attributes.projectName).write()
+            GraphWriter(nodes, attributes.projectName, nameMaps).write()
         }
         println("Project created in ${projectLanguageAttributes.first().projectName}")
     }

--- a/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/GraphWriter.kt
+++ b/project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/GraphWriter.kt
@@ -1,28 +1,32 @@
 package io.github.cdsap.projectgenerator.writer
 
+import io.github.cdsap.projectgenerator.ProjectNameMaps
 import io.github.cdsap.projectgenerator.model.ProjectGraph
-import io.github.cdsap.projectgenerator.NameMappings
 import java.io.File
 
-class GraphWriter(private val nodes: List<ProjectGraph>, val path: String) {
+class GraphWriter(
+    private val nodes: List<ProjectGraph>,
+    val path: String,
+    private val nameMaps: ProjectNameMaps
+) {
 
     fun write() {
         println("Creating graph file")
         val file = File("$path/graph.dot")
         file.createNewFile()
-        file.writeText(render(nodes))
+        file.writeText(render(nodes, nameMaps))
     }
 
     companion object {
-        fun render(nodes: List<ProjectGraph>): String {
+        fun render(nodes: List<ProjectGraph>, nameMaps: ProjectNameMaps): String {
             val content = StringBuilder()
             content.appendLine("digraph G {")
 
             for (nodeGraph in nodes) {
-                val node = "${NameMappings.layerName(nodeGraph.layer)}:${NameMappings.moduleName(nodeGraph.id)}"
+                val node = "${layerName(nameMaps, nodeGraph.layer)}:${moduleName(nameMaps, nodeGraph.id)}"
                 for (dep in nodeGraph.nodes) {
                     content.appendLine(
-                        "\"$node\" -> \"${NameMappings.layerName(dep.layer)}:${NameMappings.moduleName(dep.id)}\";"
+                        "\"$node\" -> \"${layerName(nameMaps, dep.layer)}:${moduleName(nameMaps, dep.id)}\";"
                     )
                 }
             }
@@ -30,5 +34,11 @@ class GraphWriter(private val nodes: List<ProjectGraph>, val path: String) {
             content.appendLine("}")
             return content.toString()
         }
+
+        private fun layerName(nameMaps: ProjectNameMaps, layer: Int): String =
+            nameMaps.layerNames[layer] ?: "layer_$layer"
+
+        private fun moduleName(nameMaps: ProjectNameMaps, id: String): String =
+            nameMaps.moduleNames[id] ?: id
     }
 }

--- a/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/writer/GraphWriterTest.kt
+++ b/project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/writer/GraphWriterTest.kt
@@ -1,6 +1,6 @@
 package io.github.cdsap.projectgenerator.writer
 
-import io.github.cdsap.projectgenerator.NameMappings
+import io.github.cdsap.projectgenerator.ProjectNameMaps
 import io.github.cdsap.projectgenerator.model.ProjectGraph
 import io.github.cdsap.projectgenerator.model.TypeProject
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -15,53 +15,40 @@ class GraphWriterTest {
     @TempDir
     lateinit var tempDir: Path
 
+    private val nameMaps = ProjectNameMaps(
+        layerNames = mapOf(1 to "layer_1", 2 to "app"),
+        moduleNames = mapOf("module_1_1" to "sample-lib", "module_2_1" to "app")
+    )
+
     @Test
-    fun `render builds digraph edges with layer module labels from NameMappings`() {
-        val previousLayerNames = NameMappings.layerNames
-        val previousModuleNames = NameMappings.moduleNames
-        NameMappings.layerNames = mapOf(1 to "layer_1", 2 to "app")
-        NameMappings.moduleNames = mapOf("module_1_1" to "sample-lib", "module_2_1" to "app")
-        try {
-            val lib = ProjectGraph("module_1_1", 1, emptyList(), TypeProject.LIB, 1)
-            val app = ProjectGraph("module_2_1", 2, listOf(lib), TypeProject.ANDROID_APP, 1)
+    fun `render builds digraph edges with layer module labels from ProjectNameMaps`() {
+        val lib = ProjectGraph("module_1_1", 1, emptyList(), TypeProject.LIB, 1)
+        val app = ProjectGraph("module_2_1", 2, listOf(lib), TypeProject.ANDROID_APP, 1)
 
-            val dot = GraphWriter.render(listOf(lib, app))
+        val dot = GraphWriter.render(listOf(lib, app), nameMaps)
 
-            assertEquals(
-                """
-                digraph G {
-                "app:app" -> "layer_1:sample-lib";
-                }
+        assertEquals(
+            """
+            digraph G {
+            "app:app" -> "layer_1:sample-lib";
+            }
 
-                """.trimIndent(),
-                dot
-            )
-        } finally {
-            NameMappings.layerNames = previousLayerNames
-            NameMappings.moduleNames = previousModuleNames
-        }
+            """.trimIndent(),
+            dot
+        )
     }
 
     @Test
     fun `write writes render output to graph dot`() {
-        val previousLayerNames = NameMappings.layerNames
-        val previousModuleNames = NameMappings.moduleNames
-        NameMappings.layerNames = mapOf(1 to "layer_1", 2 to "app")
-        NameMappings.moduleNames = mapOf("module_1_1" to "sample-lib", "module_2_1" to "app")
-        try {
-            val lib = ProjectGraph("module_1_1", 1, emptyList(), TypeProject.LIB, 1)
-            val app = ProjectGraph("module_2_1", 2, listOf(lib), TypeProject.ANDROID_APP, 1)
-            val nodes = listOf(lib, app)
-            val outDir = tempDir.resolve("out").toFile().also { it.mkdirs() }
+        val lib = ProjectGraph("module_1_1", 1, emptyList(), TypeProject.LIB, 1)
+        val app = ProjectGraph("module_2_1", 2, listOf(lib), TypeProject.ANDROID_APP, 1)
+        val nodes = listOf(lib, app)
+        val outDir = tempDir.resolve("out").toFile().also { it.mkdirs() }
 
-            GraphWriter(nodes, outDir.path).write()
+        GraphWriter(nodes, outDir.path, nameMaps).write()
 
-            val graphFile = File(outDir, "graph.dot")
-            assertTrue(graphFile.exists())
-            assertEquals(GraphWriter.render(nodes), graphFile.readText())
-        } finally {
-            NameMappings.layerNames = previousLayerNames
-            NameMappings.moduleNames = previousModuleNames
-        }
+        val graphFile = File(outDir, "graph.dot")
+        assertTrue(graphFile.exists())
+        assertEquals(GraphWriter.render(nodes, nameMaps), graphFile.readText())
     }
 }


### PR DESCRIPTION
## Summary

### Problem

GraphWriter.render and GraphWriter.write read the mutable global NameMappings singleton instead of receiving name mappings explicitly (GraphWriter.kt:7-25). Tests must mutate and restore global state (GraphWriterTest.kt:19-64), creating hidden coupling and reducing isolation.

### Why this matters

Graph rendering is an output concern, but its domain input is implicit global state. This makes concurrent generation and focused unit testing more fragile, and obscures the dependency between ProjectGenerator and GraphWriter.

### Proposed change

Pass ProjectNameMaps explicitly to GraphWriter and GraphWriter.render. Have ProjectGenerator retain the maps returned by ProjectNameMappingFactory.create and provide them when constructing each GraphWriter. Update GraphWriterTest to construct ProjectNameMaps directly instead of mutating NameMappings. Preserve NameMappings for the existing module-generation path.

### Notes

This establishes an explicit application-to-infrastructure boundary: ProjectGenerator owns mapping creation, while GraphWriter consumes an immutable domain value. It is a small first step toward reducing global coupling without requiring a broad rewrite.

Fixes #455

## Changes

- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/ProjectGenerator.kt`
- `project-generator/src/main/kotlin/io/github/cdsap/projectgenerator/writer/GraphWriter.kt`
- `project-generator/src/test/kotlin/io/github/cdsap/projectgenerator/writer/GraphWriterTest.kt`

## Verification

- `./gradlew :project-generator:unitTest`
- `./gradlew :cli:test`
- `./gradlew ktlintCheck`
